### PR TITLE
Fix Julia special case types

### DIFF
--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -15,22 +15,21 @@ struct TypeInstabilityError <: Exception
     T::Any
 end
 
-function extract_symb(ex::Symbol, ::String)
+function extract_symb(ex::Symbol, full_ex, ::String)
     return ex
 end
-function extract_symb(ex::Expr, type::String)
+function extract_symb(ex::Expr, full_ex, type::String)
     if ex.head == :kw
-        return extract_symb(ex.args[1], type)
+        return extract_symb(ex.args[1], full_ex, type)
     elseif ex.head == :tuple
         return ex
     elseif ex.head == :(::)
-        return extract_symb(ex.args[1], type)
+        return extract_symb(ex.args[1], full_ex, type)
     elseif ex.head == :(...)
         return ex
     else
         error(
-            "Incompatible format for function $(type): `$(ex)` " *
-            "with head=$(ex.head) args=$(ex.args). " *
+            "Incompatible format for function $(type): `$(full_ex)`. " *
             "Make sure to specify a symbol for each $(type) in the signature.",
         )
     end
@@ -39,8 +38,8 @@ end
 function _stable(fex::Expr)
     func = splitdef(fex)
 
-    arg_symbols = map(a -> extract_symb(a, "argument"), func[:args])
-    kwarg_symbols = map(a -> extract_symb(a, "keyword argument"), func[:kwargs])
+    arg_symbols = map(a -> extract_symb(a, a, "argument"), func[:args])
+    kwarg_symbols = map(a -> extract_symb(a, a, "keyword argument"), func[:kwargs])
 
     closure = gensym(string(func[:name], "_closure"))
     T = gensym(string(func[:name], "_return_type"))

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -71,12 +71,14 @@ function _stable(fex::Expr)
     # keys: :name, :args, :kwargs, :body, :whereparams
     func_runner[:name] = gensym(string(func[:name]))
 
+    arg_symbols = map(a -> extract_symb(a, "argument"), func[:args])
+    kwarg_symbols = map(a -> extract_symb(a, "keyword argument"), func[:kwargs])
     func[:body] = quote
         $(_stable_wrap)(
             $(func_runner[:name]),
             $(func[:name]),
-            $(map(a -> extract_symb(a, "argument"), func[:args])...);
-            $(map(a -> extract_symb(a, "keyword argument"), func[:kwargs])...),
+            $(arg_symbols...);
+            $(kwarg_symbols...),
         )
     end
 

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -25,6 +25,8 @@ function extract_symb(ex::Expr, type::String)
         return ex
     elseif ex.head == :(::)
         return extract_symb(ex.args[1], type)
+    elseif ex.head == :(...)
+        return ex
     else
         error(
             "Incompatible format for function $(type): `$(ex)` " *

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,15 +60,10 @@ end
         @test_throws TypeInstabilityError h(1; y=2.0)
     end
 end
-@testitem "wrap unwrap" begin
-    using DispatchDoctor: DispatchDoctor as DD
-
-    # Test that the unwrap type method is idempotent
-
-    @test DD.unwrap_type(DD.wrap_type(1.0)) == 1.0
-    @test DD.unwrap_type(DD.wrap_type(Float32)) == Float32
-    @test DD.unwrap_type(DD.wrap_type(Val(Float32))) == Val(Float32)
-    @test DD.unwrap_type(DD.wrap_type(sum)) == sum
+@testitem "Type specialization" begin
+    using DispatchDoctor
+    @stable f(a, t::Type{T}) where {T} = sum(a; init=zero(T))
+    @test f([1.0f0, 1.0f0], Float32) == 2.0f0
 end
 @testitem "showerror" begin
     using DispatchDoctor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,24 @@ end
     @stable f(a, t::Type{T}) where {T} = sum(a; init=zero(T))
     @test f([1.0f0, 1.0f0], Float32) == 2.0f0
 end
+@testitem "args and kwargs" begin
+    using DispatchDoctor
+    # Without the dots
+    @stable f1(a, args::Vararg) = sum(args) + a
+    @test f1(1, 1, 2, 3) == 7
+
+    # With the dots
+    @stable f2(a, args...) = sum(args) + a
+    @test f2(1, 1, 2, 3) == 7
+
+    # With kwargs
+    @stable f3(c; kwargs...) = sum(values(kwargs)) + c
+    @test f3(1; a=1, b=2, c=3) == 7
+
+    # With both
+    @stable f4(a, args...; d, kwargs...) = sum(args) + sum(values(kwargs)) + a + d
+    @test f4(1, 1, 2, 3; d=0, a=1, b=2, c=3) == sum((1, 1, 2, 3, 0, 1, 2, 3))
+end
 @testitem "showerror" begin
     using DispatchDoctor
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,16 @@ end
         @test_throws TypeInstabilityError h(1; y=2.0)
     end
 end
+@testitem "wrap unwrap" begin
+    using DispatchDoctor: DispatchDoctor as DD
+
+    # Test that the unwrap type method is idempotent
+
+    @test DD.unwrap_type(DD.wrap_type(1.0)) == 1.0
+    @test DD.unwrap_type(DD.wrap_type(Float32)) == Float32
+    @test DD.unwrap_type(DD.wrap_type(Val(Float32))) == Val(Float32)
+    @test DD.unwrap_type(DD.wrap_type(sum)) == sum
+end
 @testitem "showerror" begin
     using DispatchDoctor
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,10 +159,10 @@ end
 end
 @testitem "Miscellaneous" begin
     using DispatchDoctor: DispatchDoctor as DD
-    @test_throws ErrorException DD.extract_symb(:([1, 2]), "argument")
+    @test_throws ErrorException DD.extract_symb(:([1, 2]), :([1, 2, 3]), "argument")
     if VERSION >= v"1.9"
-        @test_throws "Incompatible format for function argument: `[1, 2]` with head=" DD.extract_symb(
-            :([1, 2]), "argument"
+        @test_throws "Incompatible format for function argument: `[1, 2, 3]`." DD.extract_symb(
+            :([1, 2]), :([1, 2, 3]), "argument"
         )
     end
 end


### PR DESCRIPTION
Right now the function

```julia
using DispatchDoctor
@stable f(a, t::Type{T}) where {T} = sum(a; init=zero(T))
```

is not classified as stable, even though it is. This is because of weird specialization rules: https://docs.julialang.org/en/v1.10/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing

To fix this, this PR moves back to a closure approach. This simplifies a lot of other things too and doesn't hurt performance.


This also makes it possible to use `Vararg`-args.