### PR TITLE
Add support for module-level `@stable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,45 @@ top:
 
 and thus meaning there is zero overhead on the type stability check.
 
+You can also use `@stable` on entire modules:
+
+```julia
+@stable module A
+    using DispatchDoctor: @unstable
+
+    @unstable f1() = rand(Bool) ? 0 : 1.0
+    f2(x) = x
+    f3(; a=1) = a > 0 ? a : 0.0
+end
+```
+
+where we use `@unstable` to mark functions that should not be wrapped.
+
+(*Tip: in the REPL, wrap this with `@eval`, because the REPL has special handling of the `module` keyword.*)
+
+This gives us:
+
+```julia
+julia> A.f1()
+0
+
+julia> A.f2(1.0)
+1.0
+
+julia> A.f3(a=2)
+ERROR: TypeInstabilityError: Instability detected in function `f3`
+with keyword arguments `@NamedTuple{a::Int64}`. Inferred to be
+`Union{Float64, Int64}`, which is not a concrete type.
+```
+
+where we can see that the `@stable` was automatically applied
+to all the functions, except for `f1`.
+
+> [!NOTE]
+> This will also automatically be applied to the code
+> being added by any `include` within the module, by defining
+> a custom `include` function at the top of the module.
+
 ## Credits
 
 Many thanks to @chriselrod for performance tips on this [discord thread](https://discourse.julialang.org/t/improving-speed-of-runtime-dispatch-detector/114697).

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ where we can see that the `@stable` was automatically applied
 to all the functions, except for `f1`.
 
 > [!NOTE]
-> This will also automatically be applied to the code
-> being added by any `include` within the module, by defining
-> a custom `include` function at the top of the module.
+> This will automatically propagate apply through any `include` within the module,
+> by overwriting the default method.
 
 ## Credits
 

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -2,7 +2,7 @@ module DispatchDoctor
 
 export @stable, TypeInstabilityError
 
-using MacroTools: combinedef, splitdef, postwalk, isdef, isshortdef, rmlines, prettify
+using MacroTools: combinedef, splitdef, isdef
 using TestItems: @testitem
 
 struct TypeInstabilityError <: Exception
@@ -12,23 +12,23 @@ struct TypeInstabilityError <: Exception
     T::Any
 end
 
-function extract_symb(ex::Symbol, full_ex, ::String)
+struct Unknown end
+Base.show(io::IO, ::Type{Unknown}) = print(io, "[undefined symbol]")
+
+function extract_symb(ex::Symbol)
     return ex
 end
-function extract_symb(ex::Expr, full_ex, type::String)
+function extract_symb(ex::Expr)
     if ex.head == :kw
-        return extract_symb(ex.args[1], full_ex, type)
+        return extract_symb(ex.args[1])
     elseif ex.head == :tuple
         return ex
     elseif ex.head == :(::)
-        return extract_symb(ex.args[1], full_ex, type)
+        return extract_symb(ex.args[1])
     elseif ex.head == :(...)
         return ex
     else
-        error(
-            "Incompatible format for function $(type): `$(full_ex)`. " *
-            "Make sure to specify a symbol for each $(type) in the signature.",
-        )
+        return Unknown()
     end
 end
 

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -45,7 +45,10 @@ function _stable_module(ex)
     @assert ex.head == :module
     module_body = ex.args[3]
     @assert module_body.head == :block
-    pushfirst!(module_body.args, :(include(path) = include($(_stable_all_fnc), path)))
+    pushfirst!(
+        module_body.args,
+        :(include(path::AbstractString) = include($(_stable_all_fnc), path)),
+    )
     return ex
 end
 

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -1,6 +1,6 @@
 module DispatchDoctor
 
-export @stable, TypeInstabilityError
+export @stable, @unstable, TypeInstabilityError
 
 using MacroTools: combinedef, splitdef, isdef
 using TestItems: @testitem
@@ -55,6 +55,9 @@ end
 function _stable_all_fnc(ex::Expr)
     if ex.head == :macrocall && ex.args[1] == Symbol("@stable")
         # Avoid recursive tags
+        return ex
+    elseif ex.head == :macrocall && ex.args[1] == Symbol("@unstable")
+        # Allow disabling
         return ex
     elseif isdef(ex)
         # Avoiding `MacroTools.postwalk` means we don't
@@ -128,6 +131,15 @@ which is not a concrete type.
 """
 macro stable(fex)
     return esc(_stable(fex))
+end
+
+"""
+    @unstable [func_definition]
+
+A no-op macro to mark functions as unstable when `@stable` is used on a module.
+"""
+macro unstable(fex)
+    return esc(fex)
 end
 
 function Base.showerror(io::IO, e::TypeInstabilityError)

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -45,12 +45,9 @@ function _stable_module(ex)
     @assert ex.head == :module
     module_body = ex.args[3]
     @assert module_body.head == :block
-    # f = gensym("_stable_fnc")
     pushfirst!(
         module_body.args,
         quote
-            # using DispatchDoctor: _stable_fnc as $f
-            # include(path) = include($f, path)
             include(path) = include($(_stable_fnc), path)
         end,
     )

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -48,7 +48,7 @@ function _stable_module(ex)
     pushfirst!(
         module_body.args,
         quote
-            include(path) = include($(_stable_fnc), path)
+            include(path) = include($(_stable_all_fnc), path)
         end,
     )
     return ex

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PerformanceTestTools = "dc46b164-d16f-48ec-a853-60448fc869fe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,12 +127,14 @@ end
         @test strip(string(@doc(f2))) == "Docs for my stable function."
     end
 end
-@testitem "Useful error for bad signature" begin
+@testitem "Signature without symbol" begin
     using DispatchDoctor: DispatchDoctor as DD
+    @stable f(::Type{T}) where {T} = rand(Bool) ? 0.0 : 1
+    @test_throws TypeInstabilityError f(Int)
     if VERSION >= v"1.9"
-        fdef = :(@stable f(::Type{T}) where {T} = T)
-        @test_throws LoadError eval(fdef)
-        @test_throws "Incompatible format for function argument: `::Type{T}`" eval(fdef)
+        @test_throws "TypeInstabilityError: Instability detected in function `f` with arguments `([undefined symbol],)`." f(
+            Int
+        )
     end
 end
 @testitem "modules" begin
@@ -165,12 +167,7 @@ end
 end
 @testitem "Miscellaneous" begin
     using DispatchDoctor: DispatchDoctor as DD
-    @test_throws ErrorException DD.extract_symb(:([1, 2]), :([1, 2, 3]), "argument")
-    if VERSION >= v"1.9"
-        @test_throws "Incompatible format for function argument: `[1, 2, 3]`." DD.extract_symb(
-            :([1, 2]), :([1, 2, 3]), "argument"
-        )
-    end
+    @test DD.extract_symb(:([1, 2])) == DD.Unknown()
 end
 @testitem "Code quality (Aqua.jl)" begin
     using DispatchDoctor


### PR DESCRIPTION
For example:

```julia
@stable module A
    using DispatchDoctor: @unstable

    @unstable f1() = rand(Bool) ? 0 : 1.0
    f2(x) = x
    f3(; a=1) = a > 0 ? a : 0.0
end
```

where we use `@unstable` to mark functions that should not be wrapped.

(*Tip: in the REPL, wrap this with `@eval`, because the REPL has special handling of the `module` keyword.*)

This gives us:

```julia
julia> A.f1()
0

julia> A.f2(1.0)
1.0

julia> A.f3(a=2)
ERROR: TypeInstabilityError: Instability detected in function `f3`
with keyword arguments `@NamedTuple{a::Int64}`. Inferred to be
`Union{Float64, Int64}`, which is not a concrete type.
```

where we can see that the `@stable` was automatically applied
to all the functions, except for `f1`.

> [!NOTE]
> This will also automatically be applied to the code
> being added by any `include` within the module, by defining
> a custom `include` function at the top of the module.
