### PR TITLE
Add preferences interface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,9 @@ jobs:
     name: integration-jl${{ matrix.version }}-${{ github.event_name }}-
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.2"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [compat]
 MacroTools = "0.5"
+Preferences = "1"
 TestItems = "0.1"
 julia = "1.6.7"

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Inferred to be `Union{Float64, Int64}`, which is not a concrete type.
 
 You might find it useful to *only* enable `@stable` during unit-testing,
 to have it check every function in a library, but not throw errors for
-downstream users. For this, you can use the `mode` keyword to set the
+downstream users. For this, you can use the `default_mode` keyword to set the
 default behavior:
 
 ```julia
 module MyPackage
 using DispatchDoctor
-@stable mode="disable" begin
+@stable default_mode="disable" begin
 
 # Entire package code
 
@@ -118,7 +118,7 @@ end
 end
 ```
 
-This sets the default, but the mode is configurable
+This sets the default behavior, but the mode is configurable
 via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl):
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -102,13 +102,15 @@ Inferred to be `Union{Float64, Int64}`, which is not a concrete type.
 
 (*Tip: in the REPL, you must wrap modules with `@eval`, because the REPL has special handling of the `module` keyword.*)
 
-You might find it useful to only enable `@stable` during unit-testing,
-and have it check every function in a library. For this, you can use the `enable` keyword:
+You might find it useful to *only* enable `@stable` during unit-testing,
+to have it check every function in a library, but not throw errors for
+downstream users. For this, you can use the `mode` keyword to set the
+default behavior:
 
 ```julia
 module MyPackage
 using DispatchDoctor
-@stable enable=parse(Bool, get(ENV, "MY_VAR", "false")) begin
+@stable mode=:disable begin
 
 # Entire package code
 
@@ -116,12 +118,18 @@ end
 end
 ```
 
-where you would have `test/runtests.jl` set `ENV["MY_VAR"] = "true"`
-before loading the package. Then, simply use `@unstable` to disable
-stability checks for individual functions you wish to permit instability in.
+This sets the default, but the mode is configurable
+via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl):
 
-I also like to use the `warnonly=true` option in certain contexts so
-it doesn't throw a hard error.
+```julia
+using MyPackage
+using Preferences
+
+set_preferences!(MyPackage, "instability_check" => :error)
+```
+
+which you can also set to be `:warn` if you would just like warnings.
+You might find it useful to set this during testing.
 
 You can also disable stability errors for a single scope
 with the `allow_unstable` context:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ default behavior:
 ```julia
 module MyPackage
 using DispatchDoctor
-@stable mode=:disable begin
+@stable mode="disable" begin
 
 # Entire package code
 
@@ -125,10 +125,10 @@ via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl):
 using MyPackage
 using Preferences
 
-set_preferences!(MyPackage, "instability_check" => :error)
+set_preferences!(MyPackage, "instability_check" => "error")
 ```
 
-which you can also set to be `:warn` if you would just like warnings.
+which you can also set to be `"warn"` if you would just like warnings.
 You might find it useful to set this during testing.
 
 You can also disable stability errors for a single scope

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -125,7 +125,7 @@ function _stable(args...; calling_module, kws...)
     if calling_module != Core.Main
         # Local setting from Preferences.jl overrides defaults
         mode = try
-            load_preference(get_uuid(calling_module), "instability_check", mode)
+            load_preference(get_uuid(calling_module)::Base.UUID, "instability_check", mode)
         catch
             mode
         end

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -125,7 +125,7 @@ function _stable(args...; calling_module, kws...)
     if calling_module != Core.Main
         # Local setting from Preferences.jl overrides defaults
         mode = try
-            load_preference(calling_module, "dispatch_doctor", mode)
+            load_preference(calling_module, "instability_check", mode)
         catch
             mode
         end

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -90,7 +90,7 @@ function _stable(args...; calling_module, kws...)
     options, ex = args[begin:(end - 1)], args[end]
 
     # Standard defaults:
-    mode = :error
+    mode = "error"
 
     # Deprecated
     warnonly = nothing
@@ -133,20 +133,20 @@ function _stable(args...; calling_module, kws...)
         # https://github.com/JuliaLang/PrecompileTools.jl/blob/a99446373f9a4a46d62a2889b7efb242b4ad7471/src/workloads.jl#L2C10-L11
     end
     if enable !== nothing
-        @warn "The `enable` option is deprecated. Please use `mode` instead, either :error, :warn, or :disable."
+        @warn "The `enable` option is deprecated. Please use `mode` instead, either \"error\", \"warn\", or \"disable\"."
         if warnonly !== nothing
-            @warn "The `warnonly` option is deprecated. Please use `mode` instead, either :error, :warn, or :disable."
-            mode = warnonly ? :warn : (enable ? :error : :disable)
+            @warn "The `warnonly` option is deprecated. Please use `mode` instead, either \"error\", \"warn\", or \"disable\"."
+            mode = warnonly ? "warn" : (enable ? "error" : "disable")
         else
-            mode = enable ? :error : :disable
+            mode = enable ? "error" : "disable"
         end
     end
-    if mode in (:error, :warn)
+    if mode in ("error", "warn")
         return _stabilize_all(ex; kws..., mode)
-    elseif mode == :disable
+    elseif mode == "disable"
         return ex
     else
-        error("Unknown mode: $mode. Please use :error, :warn, or :disable.")
+        error("Unknown mode: $mode. Please use \"error\", \"warn\", or \"disable\".")
     end
 end
 
@@ -202,7 +202,7 @@ function _stabilize_module(ex; kws...)
 end
 
 function _stabilize_fnc(
-    fex::Expr; mode::Symbol=:error, source_info::Union{LineNumberNode,Nothing}=nothing
+    fex::Expr; mode::String="error", source_info::Union{LineNumberNode,Nothing}=nothing
 )
     func = splitdef(fex)
 
@@ -240,7 +240,7 @@ function _stabilize_fnc(
     closure = gensym(string(name, "_closure"))
     T = gensym(string(name, "_return_type"))
 
-    err = if mode == :error
+    err = if mode == "error"
         :(throw(
             $(TypeInstabilityError)(
                 $(print_name),
@@ -251,7 +251,7 @@ function _stabilize_fnc(
                 $T,
             ),
         ))
-    elseif mode == :warn
+    elseif mode == "warn"
         :(@warn(
             $(TypeInstabilityWarning)(
                 $(print_name),
@@ -264,7 +264,7 @@ function _stabilize_fnc(
             maxlog = 1
         ))
     else
-        error("Unknown mode: $mode. Please use :error or :warn.")
+        error("Unknown mode: $mode. Please use \"error\" or \"warn\".")
     end
 
     checker = if isempty(kwarg_symbols)
@@ -382,8 +382,8 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 
 # Options
 
-- `mode::Symbol=:error`: Set this to `:warn` to only emit a warning, or
-   `:disable` to disable type instability checks altogether.
+- `mode::String="error"`: Set this to `"warn"` to only emit a warning, or
+   `"disable"` to disable type instability checks altogether.
 
 # Example
     

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -4,7 +4,7 @@ export @stable, @unstable, allow_unstable, TypeInstabilityError
 
 using MacroTools: @capture, combinedef, splitdef, isdef, longdef
 using TestItems: @testitem
-using Preferences: load_preference
+using Preferences: load_preference, get_uuid
 
 const JULIA_OK = let
     JULIA_LOWER_BOUND = v"1.10.0-DEV.0"
@@ -125,7 +125,7 @@ function _stable(args...; calling_module, kws...)
     if calling_module != Core.Main
         # Local setting from Preferences.jl overrides defaults
         mode = try
-            load_preference(calling_module, "instability_check", mode)
+            load_preference(get_uuid(calling_module), "instability_check", mode)
         catch
             mode
         end

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -103,7 +103,7 @@ function _stable(args...; calling_module, kws...)
             elseif option.args[1] == :enable
                 enable = option.args[2]
                 continue
-            elseif option.args[1] == :mode
+            elseif option.args[1] == :default_mode
                 mode = option.args[2]
                 continue
             end
@@ -382,8 +382,10 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 
 # Options
 
-- `mode::String="error"`: Set this to `"warn"` to only emit a warning, or
-   `"disable"` to disable type instability checks altogether.
+- `default_mode::String="error"`: Change the default mode to `"warn"` to only emit a warning, or
+   `"disable"` to disable type instability checks by default. To locally set the mode for
+   a package that uses DispatchDoctor, you can use the "instability_check" key in your
+   LocalPreferences.toml (typically configured with Preferences.jl)
 
 # Example
     

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -368,7 +368,7 @@ end
     using DispatchDoctor
     using Suppressor: @capture_err
     #! format: off
-    @stable mode="warn" function f(x)
+    @stable default_mode="warn" function f(x)
         x > 0 ? x : 0.0
     end
     #! format: on
@@ -390,7 +390,7 @@ end
     using DispatchDoctor
     ENV["__DISPATCH_DOCTOR_TESTING_VAR"] = "disable"
 
-    @stable mode = ENV["__DISPATCH_DOCTOR_TESTING_VAR"] function f(x)
+    @stable default_mode = ENV["__DISPATCH_DOCTOR_TESTING_VAR"] function f(x)
         return rand(Bool) ? 1 : 1.0
     end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -368,7 +368,7 @@ end
     using DispatchDoctor
     using Suppressor: @capture_err
     #! format: off
-    @stable warnonly=true function f(x)
+    @stable mode=:warn function f(x)
         x > 0 ? x : 0.0
     end
     #! format: on
@@ -388,9 +388,9 @@ end
 end
 @testitem "disable @stable using env variable" begin
     using DispatchDoctor
-    ENV["__DISPATCH_DOCTOR_TESTING_VAR"] = "false"
+    ENV["__DISPATCH_DOCTOR_TESTING_VAR"] = "disable"
 
-    @stable enable = parse(Bool, ENV["__DISPATCH_DOCTOR_TESTING_VAR"]) function f(x)
+    @stable mode = Symbol(ENV["__DISPATCH_DOCTOR_TESTING_VAR"]) function f(x)
         return rand(Bool) ? 1 : 1.0
     end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -368,7 +368,7 @@ end
     using DispatchDoctor
     using Suppressor: @capture_err
     #! format: off
-    @stable mode=:warn function f(x)
+    @stable mode="warn" function f(x)
         x > 0 ? x : 0.0
     end
     #! format: on
@@ -390,7 +390,7 @@ end
     using DispatchDoctor
     ENV["__DISPATCH_DOCTOR_TESTING_VAR"] = "disable"
 
-    @stable mode = Symbol(ENV["__DISPATCH_DOCTOR_TESTING_VAR"]) function f(x)
+    @stable mode = ENV["__DISPATCH_DOCTOR_TESTING_VAR"] function f(x)
         return rand(Bool) ? 1 : 1.0
     end
 


### PR DESCRIPTION
@mkitti what do you think?

From the new README:

> 
> You might find it useful to *only* enable `@stable` during unit-testing,
> to have it check every function in a library, but not throw errors for
> downstream users. For this, you can use the `mode` keyword to set the
> default behavior:
> 
> ```julia
> module MyPackage
> using DispatchDoctor
> @stable mode="disable" begin
> 
> # Entire package code
> 
> end
> end
> ```
> 
> This sets the default, but the mode is configurable
> via [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl):
> 
> ```julia
> using MyPackage
> using Preferences
> 
> set_preferences!(MyPackage, "instability_check" => "error")
> ```
> 
> which you can also set to be `"warn"` if you would just like warnings.
> You might find it useful to set this during testing.
