### PR TITLE
Propagate macros to function definitions

### DIFF
--- a/docs/src/macros.md
+++ b/docs/src/macros.md
@@ -12,8 +12,20 @@ with quantities are `ustrip` and `dimension`:
 
 ## Utilities
 
+If you wish to turn off `@stable` for a single function call,
+you can use `allow_unstable`:
+
 ```@docs
 allow_unstable
+```
+
+`@stable` will normally interact with macros by propagating
+them to the function definition as well as the function simulator.
+If you would like to change this behavior, or declare a macro as being
+incompatible with `@stable`, you can use `register_macro!`:
+
+```@docs
+register_macro!
 ```
 
 ## Internals

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -30,11 +30,14 @@ end
 # Macros we dont want to propagate
 const MACRO_BEHAVIOR = (;
     table=Dict([
-        Symbol("@doc") => DontPropagateMacro,               # Core.jl
-        Symbol("@generated") => IncompatibleMacro,          # Base.jl
-        Symbol("@eval") => IncompatibleMacro,               # Base.jl
-        Symbol("@model") => IncompatibleMacro,              # Turing.jl
-        Symbol("@capture") => IncompatibleMacro,            # MacroTools.jl
+        Symbol("@doc") => DontPropagateMacro,               # Core
+        Symbol("@assume_effects") => IncompatibleMacro,     # Base
+        Symbol("@eval") => IncompatibleMacro,               # Base
+        Symbol("@generated") => IncompatibleMacro,          # Base
+        Symbol("@pure") => IncompatibleMacro,               # Base
+        Symbol("@everywhere") => DontPropagateMacro,        # Distributed
+        Symbol("@model") => IncompatibleMacro,              # Turing
+        Symbol("@capture") => IncompatibleMacro,            # MacroTools
     ]),
     lock=Threads.SpinLock(),
 )

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -43,6 +43,8 @@ const MACRO_BEHAVIOR = (;
         Symbol("@generated") => IncompatibleMacro,          # Base
         # ^ In principle this is compatible but
         #   needs additional logic to work.
+        Symbol("@kwdef") => IncompatibleMacro,              # Base
+        # ^ TODO. Seems to interact in strange way.
         Symbol("@pure") => IncompatibleMacro,               # Base
         # ^ See `@assume_effects`.
         Symbol("@everywhere") => DontPropagateMacro,        # Distributed

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -258,7 +258,8 @@ function _stabilize_all(
             # We build up a stack of macros to propagate to the function call
             push!(macro_stack, ex.args[1:end-1])
             return _stabilize_all(ex.args[end], num_matches, macro_stack; kws...)
-        else  # DontPropagate
+        else
+            @assert macro_behavior == DontPropagateMacro
             return Expr(:macrocall, ex.args[1], map(e -> _stabilize_all(e, num_matches; kws...), ex.args[2:end])...)
         end
     elseif ex.head == :macro

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -31,13 +31,31 @@ end
 const MACRO_BEHAVIOR = (;
     table=Dict([
         Symbol("@doc") => DontPropagateMacro,               # Core
+        # ^ Base.@__doc__ takes care of this.
         Symbol("@assume_effects") => IncompatibleMacro,     # Base
+        # ^ Some effects are incompatible, like
+        #   :nothrow, so this requires much more
+        #   work to get working. TODO.
         Symbol("@eval") => IncompatibleMacro,               # Base
+        # ^ Too much flexibility to apply,
+        #   and user could always use `@eval`
+        #   inside function.
         Symbol("@generated") => IncompatibleMacro,          # Base
+        # ^ In principle this is compatible but
+        #   needs additional logic to work.
         Symbol("@pure") => IncompatibleMacro,               # Base
+        # ^ See `@assume_effects`.
         Symbol("@everywhere") => DontPropagateMacro,        # Distributed
+        # ^ Prefer to have block passed to workers
+        #   only a single time. And `@everywhere`
+        #   works with blocks of code, so it is
+        #   fine.
         Symbol("@model") => IncompatibleMacro,              # Turing
+        # ^ Fairly common macro used to define
+        #   probabilistic models. The syntax is
+        #   incompatible with `@stable`.
         Symbol("@capture") => IncompatibleMacro,            # MacroTools
+        # ^ Similar to `@model`.
     ]),
     lock=Threads.SpinLock(),
 )

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -574,12 +574,21 @@ end
         @test f(0) == 0
     end
 end
-@testitem "compat and incompatible macros" begin
+@testitem "multiple macro chaining takes least compatible" begin
     using DispatchDoctor
     @stable @inline @generated function f(x)
         return :(x > 0 ? x : 0.0)
     end
     @test f(0) == 0
+end
+@testitem "skip assume effects" begin
+    using DispatchDoctor
+    if DispatchDoctor.JULIA_OK && VERSION >= v"1.10.0-DEV.0"
+        @stable Base.@assume_effects :nothrow function f(x)
+            return x > 0 ? x : 0.0
+        end
+        @test f(0) == 0
+    end
 end
 @testitem "skip global" begin
     using DispatchDoctor

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -583,11 +583,13 @@ end
 end
 @testitem "skip assume effects" begin
     using DispatchDoctor
-    if DispatchDoctor.JULIA_OK && VERSION >= v"1.10.0-DEV.0"
-        @stable Base.@assume_effects :nothrow function f(x)
-            return x > 0 ? x : 0.0
+    if DispatchDoctor.JULIA_OK && VERSION >= v"1.8.0-DEV.0"
+        @eval begin
+            @stable Base.@assume_effects :nothrow function f(x)
+                return x > 0 ? x : 0.0
+            end
+            @test f(0) == 0
         end
-        @test f(0) == 0
     end
 end
 @testitem "skip global" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -548,13 +548,12 @@ end
     end
     @test f(0) == 0
 end
-@testitem "skip @propagate_inbounds" begin
-    using DispatchDoctor
-
-    @stable Base.@propagate_inbounds function f()
-        return rand(Bool) ? 1 : 1.0
-    end
-    @test f() == 1
+@testitem "propagate macros" begin
+    using DispatchDoctor: _stabilize_all, JULIA_OK
+    ex = _stabilize_all(:(Base.@propagate_inbounds function f(x)
+        return x > 0 ? x : 0.0
+    end), Ref(0))
+    JULIA_OK && @test occursin("propagate_inbounds", string(ex))
 end
 @testitem "skip global" begin
     using DispatchDoctor
@@ -580,7 +579,7 @@ end
     using InteractiveUtils: code_warntype
     @stable function f(x)
         y = Tuple(x)
-        sum(y[1:2])
+        return sum(y[1:2])
     end
     @test f([1, 2, 3]) == 3
     msg = sprint(code_warntype, f, typeof(([1, 2, 3],)))


### PR DESCRIPTION
@matthias314 I figured out a way to do it!

I also made it the default behavior. You can add custom behaviour with `register_macro!` which I added docs for.