### PR TITLE
More accurate source tracking

### DIFF
--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -179,6 +179,18 @@ function inject_symbol_to_arg(ex::Expr)
     end
 end
 
+get_first_source_info(ex) = nothing
+get_first_source_info(l::LineNumberNode) = l
+function get_first_source_info(s::Expr)
+    for arg in s.args
+        extracted_arg = get_first_source_info(arg)
+        if extracted_arg isa LineNumberNode
+            return extracted_arg
+        end
+    end
+    return nothing
+end
+
 specializing_typeof(::T) where {T} = T
 specializing_typeof(::Type{T}) where {T} = Type{T}
 specializing_typeof(::Val{T}) where {T} = Val{T}
@@ -320,18 +332,6 @@ function _stabilize_module(ex, num_matches::Ref{Int}; kws...)
         Expr(:block, map(e -> _stabilize_all(e, num_matches; kws...), ex.args[3].args)...),
     )
     return ex
-end
-
-get_first_source_info(ex) = nothing
-get_first_source_info(l::LineNumberNode) = l
-function get_first_source_info(s::Expr)
-    for arg in s.args
-        extracted_arg = get_first_source_info(arg)
-        if extracted_arg isa LineNumberNode
-            return extracted_arg
-        end
-    end
-    return nothing
 end
 
 function _stabilize_fnc(

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -334,13 +334,6 @@ end
     if VERSION >= v"1.9"
         @test_throws " anonymous function defined at " f()
     end
-
-    # Without source info, we just get "anonymous function"
-    f2 = eval(_stabilize_fnc(:(() -> rand(Bool) ? Float32 : Float64), Ref(0)))
-    DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f2()
-    if VERSION >= v"1.9"
-        @test_throws "anonymous function. Inferred" f2()
-    end
 end
 @testitem "skip empty functions" begin
     using DispatchDoctor: _stabilize_fnc, _stabilize_all


### PR DESCRIPTION
Basically it just extracts the first `LineNumberNode` in the expression and puts that in the error message/warning message. So even if the Julia backtrace is innaccurate, at least that part is decent.