### PR TITLE
Don't gensym `return_type`

### DIFF
--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -385,7 +385,7 @@ function _stabilize_fnc(
     where_param_symbols = map(extract_symbol, where_params)
 
     simulator = gensym(string(name, "_simulator"))
-    T = gensym(string(name, "_return_type"))
+    T = :return_type
 
     err = if mode == "error"
         :(throw(


### PR DESCRIPTION
Just a suggestion, and a rather inconsequential one at that---but there doesn't appear to be any need for a gensymmed name for the return type variable. Using a plain symbol here slightly improves the readability of the outputs of `@macroexpand`, `@code_warntype`, et cetera.