### PR TITLE
Fix type of type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchDoctor"
 uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,4 +105,8 @@ return false for `Union{}`, so that errors can propagate.
 @inline type_instability(::Type{T}) where {T} = !Base.isconcretetype(T)
 @inline type_instability(::Type{Union{}}) = false
 
+# Weirdly, Base.isconcretetype flags Type{T} itself as not concrete,
+# so we implement a workaround.
+@inline type_instability(::Type{Type{T}}) where {T} = type_instability(T)
+
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -435,6 +435,23 @@ end
 
     @test_throws MethodError my_bad_function(1)
 end
+@testitem "dont flag Type{T} as not concrete" begin
+    using DispatchDoctor
+
+    @stable function f(t)
+        return t
+    end
+
+    @test f(Float32) == Float32
+
+    @test !Base.isconcretetype(Type{Float32})
+
+    # We have a special method to fix this:
+    @test !DispatchDoctor.type_instability(Type{Float32})
+
+    # Will work recursively
+    @test !DispatchDoctor.type_instability(Type{Type{Float32}})
+end
 @testitem "begin block" begin
     using DispatchDoctor
 


### PR DESCRIPTION
Fixes an edge case of `Base.isconcretetype` where `Type{Float32}` will result in `false`.