### PR TITLE
automatically skip `Base.iterate`

### DIFF
--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -18,7 +18,7 @@ using ._Utils: extract_symbol, JULIA_OK, Unknown, specializing_typeof, type_inst
 using ._Errors: TypeInstabilityError, TypeInstabilityWarning, AllowUnstableDataRace
 using ._Preferences
 using ._Printing
-using ._MacroInteractions: MACRO_BEHAVIOR, MacroInteractions, CompatibleMacro, IncompatibleMacro, DontPropagateMacro, register_macro!, get_macro_behavior
+using ._Interactions: MACRO_BEHAVIOR, MacroInteractions, CompatibleMacro, IncompatibleMacro, DontPropagateMacro, register_macro!, get_macro_behavior, ignore_function
 using ._RuntimeChecks: INSTABILITY_CHECK_ENABLED, allow_unstable, is_precompiling
 using ._Stabilization: _stable, _stabilize_all, _stabilize_fnc, _stabilize_module
 using ._Macros: @stable, @unstable

--- a/src/macro_interactions.jl
+++ b/src/macro_interactions.jl
@@ -1,5 +1,5 @@
-"""This module describes interactions between `@stable` and other macros"""
-module _MacroInteractions
+"""This module describes interactions between `@stable` and other macros and functions"""
+module _Interactions
 
 """
 An enum to describe the behavior of macros when interacting with `@stable`.
@@ -104,5 +104,14 @@ function register_macro!(macro_name::Symbol, behavior::MacroInteractions)
         MACRO_BEHAVIOR.table[macro_name]
     end
 end
+
+"""
+    ignore_function(f)
+
+Globally ignore certain functions when stabilizing.
+By default, `Base.iterate` is ignored, as it is meant to be unstable.
+"""
+@inline ignore_function(f) = false
+@inline ignore_function(::typeof(iterate)) = true
 
 end

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -12,8 +12,12 @@ using .._Utils:
     type_instability
 using .._Errors: TypeInstabilityError, TypeInstabilityWarning
 using .._Preferences: get_preferred_mode
-using .._MacroInteractions:
-    get_macro_behavior, IncompatibleMacro, CompatibleMacro, DontPropagateMacro
+using .._Interactions:
+    ignore_function,
+    get_macro_behavior,
+    IncompatibleMacro,
+    CompatibleMacro,
+    DontPropagateMacro
 using .._RuntimeChecks: is_precompiling, checking_enabled
 
 function _stable(args...; calling_module, source_info, kws...)
@@ -306,10 +310,15 @@ function _stabilize_fnc(
         ))
     end
 
+    ignore_func = haskey(func, :name) ? :($(ignore_function)($(func[:name]))) : :(false)
+
     func_simulator[:name] = simulator
     func[:body] = quote
         $T = $checker
-        if $(type_instability)($T) && !$(is_precompiling)() && $(checking_enabled)()
+        if $(type_instability)($T) &&
+            !$ignore_func &&
+            !$(is_precompiling)() &&
+            $(checking_enabled)()
             $err
         end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -680,6 +680,18 @@ end
         end
     end
 end
+@testitem "skip Base.iterate" begin
+    using DispatchDoctor
+    struct MyTypeIterate end
+    @stable begin
+        f(x) = x > 0 ? x : 0.0
+        Base.iterate(::MyTypeIterate) = (1, 1)
+    end
+    if DispatchDoctor.JULIA_OK
+        @test_throws TypeInstabilityError f(0)
+        @test iterate(MyTypeIterate()) == (1, 1)
+    end
+end
 @testitem "skip global" begin
     using DispatchDoctor
     @stable struct A


### PR DESCRIPTION
`Base.iterate` is unstable by default. I don't agree with the design choice but since it always is, even for user's code, there's no reason to flag it.