### PR TITLE
Add `codegen_level` parameter for minimal codegen

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -13,10 +13,16 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 
 # Options
 
-- `default_mode::String="error"`: Change the default mode to `"warn"` to only emit a warning, or
+- `default_mode::String="error"`: Change the default mode from `"error"` to `"warn"` to only emit a warning, or
    `"disable"` to disable type instability checks by default. To locally set the mode for
-   a package that uses DispatchDoctor, you can use the "instability_check" key in your
-   LocalPreferences.toml (typically configured with Preferences.jl)
+   a package that uses DispatchDoctor, you can use the `"instability_check"`` key in your
+   LocalPreferences.toml (typically configured with Preferences.jl).
+- `default_codegen_level::String="debug"`: Set the code generation level to `"min"` to only generate
+   a single function body for each stabilized function. The default, `"debug"`, generates an
+   entire duplicate function so that `@code_warntype` can be used. To locally set the code generation
+   level for a package that uses DispatchDoctor, you can use the "instability_check_codegen" key in your
+   LocalPreferences.toml.
+
 
 # Example
     

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -3,11 +3,14 @@ module _Preferences
 
 using Preferences: load_preference, get_uuid
 
-function get_preferred_mode(mode, calling_module)
+const GLOBAL_DEFAULT_MODE = "error"
+const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
+
+function get_preferred(default, calling_module, key)
     try
-        load_preference(get_uuid(calling_module)::Base.UUID, "instability_check", mode)
+        load_preference(get_uuid(calling_module)::Base.UUID, key, default)
     catch
-        mode
+        default
     end
 end
 


### PR DESCRIPTION
Reduces precompilation time increase noted by @thofman

This allows you to set `default_codegen_level="min"` which will avoid duplicating function bodies, without affecting anything else. The reason for the function body duplication is literally just to get `@code_warntype` working, but nothing else.

 There is also a Preferences.jl key for it: `instability_check_codegen` (which overrides the default).

With `default_codegen_level="min"`, you can't use `@code_warntype`. So the default is `"debug"`. But if you are building a massive library, I can totally see `"min"` being useful to cut down compilation time.