### PR TITLE
Implement mechanism for ignoring unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ top:
 
 Meaning there is zero overhead on this type stability check.
 
-You can also use `@stable` on blocks of code,
+You can use `@stable` on blocks of code,
 including `begin-end` blocks, `module`, and anonymous functions.
 The inverse of `@stable` is `@unstable` which turns it off:
 
@@ -119,14 +119,29 @@ julia> allow_unstable() do
 although this will error if you try to use it simultaneously
 from two separate threads.
 
+### Options
+
+You can provide the following options to `@stable`:
+
+- `default_mode::String="error"`:
+  - Change the default mode from `"error"` to `"warn"` to only emit a warning, or `"disable"` to disable type instability checks by default.
+  - To locally or globally override the mode for a package that uses DispatchDoctor, you can use the `"instability_check"` key in your LocalPreferences.toml (typically configured with Preferences.jl).
+- `default_codegen_level::String="debug"`:
+  - Set the code generation level to `"min"` to only generate a single function body for each stabilized function. The default, `"debug"`, generates an entire duplicate function so that `@code_warntype` can be used.
+  - To locally or globally override the code generation level for a package that uses DispatchDoctor, you can use the `"instability_check_codegen"` key in your LocalPreferences.toml.
+- `default_union_limit::Int=1`:
+  - Sets the maximum elements in a union to be considered stable. The default is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}` is considered stable, but `Union{Float16,Float32,Float64}` is not.
+  - To locally or globally override the union limit for a package that uses DispatchDoctor, you can use the `"instability_check_union_limit"` key in your LocalPreferences.toml.
+
+Each of these is denoted a `default_` because you may set them globally or at a per-package level with `Preferences.jl` (see below).
+
 ### Usage in packages
 
 You might find it useful to *only* enable `@stable` during unit-testing,
 to have it check every function in a library, but not throw errors for
 downstream users. You may also want to have warnings instead of errors.
 
-For this, you can use the `default_mode` keyword to set the
-default behavior:
+For this, use the `default_mode` keyword to set the default behavior:
 
 ```julia
 module MyPackage

--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -10,6 +10,7 @@ include("printing.jl")
 include("runtime_checks.jl")
 include("preferences.jl")
 include("macro_interactions.jl")
+include("parse_options.jl")
 include("stabilization.jl")
 include("macros.jl")
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -14,16 +14,19 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 # Options
 
 - `default_mode::String="error"`: Change the default mode from `"error"` to `"warn"` to only emit a warning, or
-   `"disable"` to disable type instability checks by default. To locally set the mode for
+   `"disable"` to disable type instability checks by default. To locally or globally override the mode for
    a package that uses DispatchDoctor, you can use the `"instability_check"`` key in your
    LocalPreferences.toml (typically configured with Preferences.jl).
 - `default_codegen_level::String="debug"`: Set the code generation level to `"min"` to only generate
    a single function body for each stabilized function. The default, `"debug"`, generates an
-   entire duplicate function so that `@code_warntype` can be used. To locally set the code generation
-   level for a package that uses DispatchDoctor, you can use the "instability_check_codegen" key in your
-   LocalPreferences.toml.
-- `default_ignore_union::Bool=false`: Set to `true` to ignore unions as a type of instability for the
-    stabilized block of code.
+   entire duplicate function so that `@code_warntype` can be used. To locally or globally override
+   the code generation level for a package that uses DispatchDoctor, you can use the
+   "instability_check_codegen" key in your LocalPreferences.toml.
+- `default_union_limit::Int=1`: Sets the maximum elements in a union to be considered stable. The default
+   is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}`
+   is considered stable, but `Union{Float16,Float32,Float64}` is not. To locally or globally override
+   the union limit for a package that uses DispatchDoctor, you can use the "instability_check_union_limit"
+   key in your LocalPreferences.toml.
 
 
 # Example

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -13,20 +13,15 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 
 # Options
 
-- `default_mode::String="error"`: Change the default mode from `"error"` to `"warn"` to only emit a warning, or
-   `"disable"` to disable type instability checks by default. To locally or globally override the mode for
-   a package that uses DispatchDoctor, you can use the `"instability_check"`` key in your
-   LocalPreferences.toml (typically configured with Preferences.jl).
-- `default_codegen_level::String="debug"`: Set the code generation level to `"min"` to only generate
-   a single function body for each stabilized function. The default, `"debug"`, generates an
-   entire duplicate function so that `@code_warntype` can be used. To locally or globally override
-   the code generation level for a package that uses DispatchDoctor, you can use the
-   "instability_check_codegen" key in your LocalPreferences.toml.
-- `default_union_limit::Int=1`: Sets the maximum elements in a union to be considered stable. The default
-   is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}`
-   is considered stable, but `Union{Float16,Float32,Float64}` is not. To locally or globally override
-   the union limit for a package that uses DispatchDoctor, you can use the "instability_check_union_limit"
-   key in your LocalPreferences.toml.
+- `default_mode::String="error"`:
+  - Change the default mode from `"error"` to `"warn"` to only emit a warning, or `"disable"` to disable type instability checks by default.
+  - To locally or globally override the mode for a package that uses DispatchDoctor, you can use the `"instability_check"` key in your LocalPreferences.toml (typically configured with Preferences.jl).
+- `default_codegen_level::String="debug"`:
+  - Set the code generation level to `"min"` to only generate a single function body for each stabilized function. The default, `"debug"`, generates an entire duplicate function so that `@code_warntype` can be used.
+  - To locally or globally override the code generation level for a package that uses DispatchDoctor, you can use the `"instability_check_codegen"` key in your LocalPreferences.toml.
+- `default_union_limit::Int=1`:
+  - Sets the maximum elements in a union to be considered stable. The default is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}` is considered stable, but `Union{Float16,Float32,Float64}` is not.
+  - To locally or globally override the union limit for a package that uses DispatchDoctor, you can use the `"instability_check_union_limit"` key in your LocalPreferences.toml.
 
 
 # Example

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -22,6 +22,8 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
    entire duplicate function so that `@code_warntype` can be used. To locally set the code generation
    level for a package that uses DispatchDoctor, you can use the "instability_check_codegen" key in your
    LocalPreferences.toml.
+- `default_ignore_union::Bool=false`: Set to `true` to ignore unions as a type of instability for the
+    stabilized block of code.
 
 
 # Example

--- a/src/parse_options.jl
+++ b/src/parse_options.jl
@@ -1,0 +1,92 @@
+module _ParseOptions
+
+using .._Preferences:
+    get_preferred,
+    GLOBAL_DEFAULT_MODE,
+    GLOBAL_DEFAULT_CODEGEN_LEVEL,
+    GLOBAL_DEFAULT_IGNORE_UNION
+
+struct StabilizationOptions
+    mode::String
+    codegen_level::String
+    ignore_union::Bool
+end
+
+function parse_options(options, calling_module)
+    # Standard defaults:
+    mode = GLOBAL_DEFAULT_MODE
+    codegen_level = GLOBAL_DEFAULT_CODEGEN_LEVEL
+    ignore_union = GLOBAL_DEFAULT_IGNORE_UNION
+
+    # Deprecated
+    warnonly = nothing
+    enable = nothing
+
+    for option in options
+        if option isa Expr && option.head == :(=)
+            if option.args[1] == :warnonly
+                warnonly = option.args[2]
+                continue
+            elseif option.args[1] == :enable
+                enable = option.args[2]
+                continue
+            elseif option.args[1] == :default_mode
+                mode = option.args[2]
+                continue
+            elseif option.args[1] == :default_codegen_level
+                codegen_level = option.args[2]
+                continue
+            elseif option.args[1] == :default_ignore_union
+                ignore_union = option.args[2]
+                continue
+            end
+        end
+        error("Unknown macro option: $option")
+    end
+
+    # Load in any expression-based options
+    #! format: off
+    mode = mode isa Expr ? Core.eval(calling_module, mode) : (mode isa QuoteNode ? mode.value : mode)
+    codegen_level = codegen_level isa QuoteNode ? codegen_level.value : codegen_level
+    ignore_union = ignore_union isa QuoteNode ? ignore_union.value : ignore_union
+    #! format: on
+    # TODO: Deprecate passing expression here.
+
+    if mode ∉ ("error", "warn", "disable")
+        error("Unknown mode: $mode. Please use \"error\", \"warn\", or \"disable\".")
+    end
+    if codegen_level ∉ ("debug", "min")
+        error("Unknown codegen level: $codegen_level. Please use \"debug\" or \"min\".")
+    end
+
+    mode::String
+    codegen_level::String
+    ignore_union::Bool
+
+    # Deprecated
+    warnonly = warnonly isa Expr ? Core.eval(calling_module, warnonly) : warnonly
+    enable = enable isa Expr ? Core.eval(calling_module, enable) : enable
+
+    if calling_module != Core.Main
+        # Local setting from Preferences.jl overrides defaults
+        #! format: off
+        mode = get_preferred(mode, calling_module, "instability_check")
+        codegen_level = get_preferred(codegen_level, calling_module, "instability_check_codegen")
+        ignore_union = get_preferred(ignore_union, calling_module, "instability_check_ignore_union")
+        #! format: on
+        # TODO: Why do we need this try-catch? Seems like its used by e.g.,
+        # https://github.com/JuliaLang/PrecompileTools.jl/blob/a99446373f9a4a46d62a2889b7efb242b4ad7471/src/workloads.jl#L2C10-L11
+    end
+    if enable !== nothing
+        @warn "The `enable` option is deprecated. Please use `default_mode` instead, either \"error\", \"warn\", or \"disable\"."
+        if warnonly !== nothing
+            @warn "The `warnonly` option is deprecated. Please use `default_mode` instead, either \"error\", \"warn\", or \"disable\"."
+            mode = warnonly ? "warn" : (enable ? "error" : "disable")
+        else
+            mode = enable ? "error" : "disable"
+        end
+    end
+    return StabilizationOptions(mode, codegen_level, ignore_union)
+end
+
+end

--- a/src/parse_options.jl
+++ b/src/parse_options.jl
@@ -1,3 +1,4 @@
+"""This module parses the options for the `@stable` macro"""
 module _ParseOptions
 
 using .._Preferences:

--- a/src/parse_options.jl
+++ b/src/parse_options.jl
@@ -4,19 +4,19 @@ using .._Preferences:
     get_preferred,
     GLOBAL_DEFAULT_MODE,
     GLOBAL_DEFAULT_CODEGEN_LEVEL,
-    GLOBAL_DEFAULT_IGNORE_UNION
+    GLOBAL_DEFAULT_UNION_LIMIT
 
 struct StabilizationOptions
     mode::String
     codegen_level::String
-    ignore_union::Bool
+    union_limit::Int
 end
 
 function parse_options(options, calling_module)
     # Standard defaults:
     mode = GLOBAL_DEFAULT_MODE
     codegen_level = GLOBAL_DEFAULT_CODEGEN_LEVEL
-    ignore_union = GLOBAL_DEFAULT_IGNORE_UNION
+    union_limit = GLOBAL_DEFAULT_UNION_LIMIT
 
     # Deprecated
     warnonly = nothing
@@ -36,8 +36,8 @@ function parse_options(options, calling_module)
             elseif option.args[1] == :default_codegen_level
                 codegen_level = option.args[2]
                 continue
-            elseif option.args[1] == :default_ignore_union
-                ignore_union = option.args[2]
+            elseif option.args[1] == :default_union_limit
+                union_limit = option.args[2]
                 continue
             end
         end
@@ -48,7 +48,7 @@ function parse_options(options, calling_module)
     #! format: off
     mode = mode isa Expr ? Core.eval(calling_module, mode) : (mode isa QuoteNode ? mode.value : mode)
     codegen_level = codegen_level isa QuoteNode ? codegen_level.value : codegen_level
-    ignore_union = ignore_union isa QuoteNode ? ignore_union.value : ignore_union
+    union_limit = union_limit isa QuoteNode ? union_limit.value : union_limit
     #! format: on
     # TODO: Deprecate passing expression here.
 
@@ -61,7 +61,7 @@ function parse_options(options, calling_module)
 
     mode::String
     codegen_level::String
-    ignore_union::Bool
+    union_limit::Int
 
     # Deprecated
     warnonly = warnonly isa Expr ? Core.eval(calling_module, warnonly) : warnonly
@@ -72,7 +72,7 @@ function parse_options(options, calling_module)
         #! format: off
         mode = get_preferred(mode, calling_module, "instability_check")
         codegen_level = get_preferred(codegen_level, calling_module, "instability_check_codegen")
-        ignore_union = get_preferred(ignore_union, calling_module, "instability_check_ignore_union")
+        union_limit = get_preferred(union_limit, calling_module, "instability_check_union_limit")
         #! format: on
         # TODO: Why do we need this try-catch? Seems like its used by e.g.,
         # https://github.com/JuliaLang/PrecompileTools.jl/blob/a99446373f9a4a46d62a2889b7efb242b4ad7471/src/workloads.jl#L2C10-L11
@@ -86,7 +86,7 @@ function parse_options(options, calling_module)
             mode = enable ? "error" : "disable"
         end
     end
-    return StabilizationOptions(mode, codegen_level, ignore_union)
+    return StabilizationOptions(mode, codegen_level, union_limit)
 end
 
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -5,6 +5,7 @@ using Preferences: load_preference, get_uuid
 
 const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
+const GLOBAL_DEFAULT_IGNORE_UNION = false
 
 function get_preferred(default, calling_module, key)
     try

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -5,7 +5,7 @@ using Preferences: load_preference, get_uuid
 
 const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
-const GLOBAL_DEFAULT_IGNORE_UNION = false
+const GLOBAL_DEFAULT_UNION_LIMIT = 1
 
 function get_preferred(default, calling_module, key)
     try

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -3,6 +3,12 @@ module _Preferences
 
 using Preferences: load_preference, get_uuid
 
+struct StabilizationOptions
+    mode::String
+    codegen_level::String
+    union_limit::Int
+end
+
 const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
 const GLOBAL_DEFAULT_UNION_LIMIT = 1
@@ -13,6 +19,13 @@ function get_preferred(default, calling_module, key)
     catch
         default
     end
+end
+function get_all_preferred(options::StabilizationOptions, calling_module)
+    return StabilizationOptions(
+        get_preferred(options.mode, calling_module, "instability_check"),
+        get_preferred(options.codegen_level, calling_module, "instability_check_codegen"),
+        get_preferred(options.union_limit, calling_module, "instability_check_union_limit"),
+    )
 end
 
 end

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -11,7 +11,6 @@ using .._Utils:
     extract_symbol,
     type_instability
 using .._Errors: TypeInstabilityError, TypeInstabilityWarning
-using .._Preferences: get_preferred, GLOBAL_DEFAULT_MODE, GLOBAL_DEFAULT_CODEGEN_LEVEL
 using .._Interactions:
     ignore_function,
     get_macro_behavior,
@@ -19,80 +18,15 @@ using .._Interactions:
     CompatibleMacro,
     DontPropagateMacro
 using .._RuntimeChecks: is_precompiling, checking_enabled
+using .._ParseOptions: parse_options
 
 function _stable(args...; calling_module, source_info, kws...)
-    options, ex = args[begin:(end - 1)], args[end]
+    raw_options, ex = args[begin:(end - 1)], args[end]
+    options = parse_options(raw_options, calling_module)
 
-    # Standard defaults:
-    mode = GLOBAL_DEFAULT_MODE
-    codegen_level = GLOBAL_DEFAULT_CODEGEN_LEVEL
-
-    # Deprecated
-    warnonly = nothing
-    enable = nothing
-    for option in options
-        if option isa Expr && option.head == :(=)
-            if option.args[1] == :warnonly
-                warnonly = option.args[2]
-                continue
-            elseif option.args[1] == :enable
-                enable = option.args[2]
-                continue
-            elseif option.args[1] == :default_mode
-                mode = option.args[2]
-                continue
-            elseif option.args[1] == :default_codegen_level
-                codegen_level = option.args[2]
-                continue
-            end
-        end
-        error("Unknown macro option: $option")
-    end
-
-    # Load in any expression-based options
-    mode = if mode isa Expr
-        Core.eval(calling_module, mode)
-    else
-        (mode isa QuoteNode ? mode.value : mode)
-    end
-    # TODO: Deprecate passing expression here.
-    codegen_level = codegen_level isa QuoteNode ? codegen_level.value : codegen_level
-
-    if mode ∉ ("error", "warn", "disable")
-        error("Unknown mode: $mode. Please use \"error\", \"warn\", or \"disable\".")
-    end
-    if codegen_level ∉ ("debug", "min")
-        error("Unknown codegen level: $codegen_level. Please use \"debug\" or \"min\".")
-    end
-
-    mode::String
-    codegen_level::String
-
-    # Deprecated
-    warnonly = warnonly isa Expr ? Core.eval(calling_module, warnonly) : warnonly
-    enable = enable isa Expr ? Core.eval(calling_module, enable) : enable
-
-    if calling_module != Core.Main
-        # Local setting from Preferences.jl overrides defaults
-        mode = get_preferred(mode, calling_module, "instability_check")
-        codegen_level = get_preferred(
-            codegen_level, calling_module, "instability_check_codegen"
-        )
-        # TODO: Why do we need this try-catch? Seems like its used by e.g.,
-        # https://github.com/JuliaLang/PrecompileTools.jl/blob/a99446373f9a4a46d62a2889b7efb242b4ad7471/src/workloads.jl#L2C10-L11
-    end
-    if enable !== nothing
-        @warn "The `enable` option is deprecated. Please use `default_mode` instead, either \"error\", \"warn\", or \"disable\"."
-        if warnonly !== nothing
-            @warn "The `warnonly` option is deprecated. Please use `default_mode` instead, either \"error\", \"warn\", or \"disable\"."
-            mode = warnonly ? "warn" : (enable ? "error" : "disable")
-        else
-            mode = enable ? "error" : "disable"
-        end
-    end
-    if mode in ("error", "warn")
+    if options.mode in ("error", "warn")
         out, metadata = _stabilize_all(
-            ex, DownwardMetadata(); source_info, kws..., mode, codegen_level
+            ex, DownwardMetadata(); source_info, kws..., options.mode, options.codegen_level
         )
         if metadata.matching_function == 0
             @warn(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -109,4 +109,9 @@ return false for `Union{}`, so that errors can propagate.
 # so we implement a workaround.
 @inline type_instability(::Type{Type{T}}) where {T} = type_instability(T)
 
+# Ignore unions to allow for union splitting
+@inline function type_instability_no_union(::Type{T}) where {T}
+    return T isa Union ? false : type_instability(T)
+end
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -111,7 +111,11 @@ return false for `Union{}`, so that errors can propagate.
 
 # Ignore unions to allow for union splitting
 @inline function type_instability_no_union(::Type{T}) where {T}
-    return T isa Union ? false : type_instability(T)
+    if T isa Union
+        return type_instability_no_union(T.a) || type_instability_no_union(T.b)
+    else
+        return type_instability(T)
+    end
 end
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,12 +110,13 @@ return false for `Union{}`, so that errors can propagate.
 @inline type_instability(::Type{Type{T}}) where {T} = type_instability(T)
 
 # Ignore unions to allow for union splitting
-@inline function type_instability_no_union(::Type{T}) where {T}
-    if T isa Union
-        return type_instability_no_union(T.a) || type_instability_no_union(T.b)
+@generated function type_instability_no_union(::Type{T}) where {T}
+    result = if T isa Union
+        type_instability_no_union(T.a) || type_instability_no_union(T.b)
     else
-        return type_instability(T)
+        type_instability(T)
     end
+    return :($result)
 end
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -109,14 +109,21 @@ return false for `Union{}`, so that errors can propagate.
 # so we implement a workaround.
 @inline type_instability(::Type{Type{T}}) where {T} = type_instability(T)
 
-# Ignore unions to allow for union splitting
-@generated function type_instability_no_union(::Type{T}) where {T}
-    result = if T isa Union
-        type_instability_no_union(T.a) || type_instability_no_union(T.b)
+@generated function type_instability_limit_unions(
+    ::Type{T}, ::Val{union_limit}
+) where {T,union_limit}
+    result = _type_instability_recurse_unions(T) || _count_unions(T) > union_limit
+    return result
+end
+
+_count_unions(::Type{T}) where {T} = T isa Union ? (1 + _count_unions(T.b)) : 1
+
+function _type_instability_recurse_unions(::Type{T}) where {T}
+    if T isa Union
+        type_instability(T.a) || _type_instability_recurse_unions(T.b)
     else
         type_instability(T)
     end
-    return :($result)
 end
 
 end

--- a/test/dynamic_expressions.jl
+++ b/test/dynamic_expressions.jl
@@ -10,7 +10,8 @@ repo_url = "https://github.com/SymbolicML/DynamicExpressions.jl.git"
 destination_folder = joinpath(tempdir, "DynamicExpressions")
 commit_sha = "ea0076e263e559467a3a5d11996cbddc7c08f36b"
 
-run(`$(git()) clone --depth=1 "$repo_url" "$destination_folder"`)
+run(`$(git()) clone "$repo_url" "$destination_folder"`)
+run(`$(git()) -C "$destination_folder" checkout $commit_sha`)
 
 # Make edits to use DispatchDoctor:
 let
@@ -22,7 +23,7 @@ let
     insert!(lines, 3, "@stable default_mode=\"warn\" begin")
 
     # Find the index of the line to insert 'end' after 'include("Random.jl")'
-    index = findfirst(isequal("include(\"Random.jl\")"), lines)::Integer
+    index = findfirst(h -> occursin("include(\"Random.jl\")", h), lines)::Integer
     insert!(lines, index + 1, "end")
 
     new_contents = join(lines, "\n")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -848,6 +848,21 @@ end
     @test f(0) == 0
     DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g()
 end
+@testitem "disallow union if any element is unstable" begin
+    using DispatchDoctor
+    @stable default_ignore_union = true function f(x)
+        return x > 0 ? Val(rand()) : x
+    end
+    # This should still fail because one of the elements is unstable!
+    DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(0)
+end
+@testitem "unionall within union" begin
+    using DispatchDoctor
+    @stable default_ignore_union = true function f(x)
+        return [x > 0 ? Val(rand()) : x]
+    end
+    DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(0)
+end
 @testitem "skip global" begin
     using DispatchDoctor
     @stable struct A

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -839,7 +839,7 @@ end
 end
 @testitem "conditionally allow union instabilities" begin
     using DispatchDoctor
-    @stable default_ignore_union = true begin
+    @stable default_union_limit = 2 begin
         # Just a union:
         f(x) = x > 0 ? x : 0.0
         # Full-blown type instability:
@@ -850,7 +850,7 @@ end
 end
 @testitem "disallow union if any element is unstable" begin
     using DispatchDoctor
-    @stable default_ignore_union = true function f(x)
+    @stable default_union_limit = 2 function f(x)
         return x > 0 ? Val(rand()) : x
     end
     # This should still fail because one of the elements is unstable!
@@ -858,10 +858,31 @@ end
 end
 @testitem "unionall within union" begin
     using DispatchDoctor
-    @stable default_ignore_union = true function f(x)
+    @stable default_union_limit = 2 function f(x)
         return [x > 0 ? Val(rand()) : x]
     end
     DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(0)
+end
+@testitem "larger union limit" begin
+    using DispatchDoctor
+
+    # Breaks with 4 unions:
+    @stable default_union_limit = 3 function f(x)
+        x = Union{Float16,Float32,Float64,BigFloat}[
+            one(Float16), one(Float32), one(Float64), one(BigFloat)
+        ]
+        return x[rand(1:4)]
+    end
+    DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(0)
+
+    # But, now it works:
+    @stable default_union_limit = 4 function f(x)
+        x = Union{Float16,Float32,Float64,BigFloat}[
+            one(Float16), one(Float32), one(Float64), one(BigFloat)
+        ]
+        return x[rand(1:4)]
+    end
+    @test f(0) == 1
 end
 @testitem "skip global" begin
     using DispatchDoctor

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -837,6 +837,17 @@ end
         @test iterate(MyTypeIterate()) == (1, 1)
     end
 end
+@testitem "conditionally allow union instabilities" begin
+    using DispatchDoctor
+    @stable default_ignore_union = true begin
+        # Just a union:
+        f(x) = x > 0 ? x : 0.0
+        # Full-blown type instability:
+        g() = Val(rand())
+    end
+    @test f(0) == 0
+    DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g()
+end
 @testitem "skip global" begin
     using DispatchDoctor
     @stable struct A


### PR DESCRIPTION
@ChrisRackauckas is this what you are looking for?

For example:

```julia
@stable default_ignore_union = true begin
    # Just a union:
    f(x) = x > 0 ? x : 0.0
    # Full-blown type instability:
    g() = Val(rand())
end


f(0) # No error; just a union
@test_throws TypeInstabilityError g()
```

This doesn't affect any existing code as `ignore_union` is set to true by default. As with other parameters you can configure this with Preferences.jl – `instability_check_ignore_union` is the new parameter here.

As usual this should be removed by the compiler if the code is stable.

Fixes #29. The PR also moves the options parsing to a new file `parse_options.jl`.