### PR TITLE
Fix union limit edge-case within tuple

### DIFF
--- a/src/DispatchDoctor.jl
+++ b/src/DispatchDoctor.jl
@@ -15,7 +15,7 @@ include("stabilization.jl")
 include("macros.jl")
 
 #! format: off
-using ._Utils: extract_symbol, JULIA_OK, Unknown, specializing_typeof, type_instability
+using ._Utils: extract_symbol, JULIA_OK, Unknown, specializing_typeof, type_instability, type_instability_limit_unions
 using ._Errors: TypeInstabilityError, TypeInstabilityWarning, AllowUnstableDataRace
 using ._Preferences
 using ._Printing

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -884,6 +884,25 @@ end
     end
     @test f(0) == 1
 end
+@testitem "union limit respects tuple" begin
+    import DispatchDoctor as DD
+
+    U2 = Union{Float32,Float64}
+    U3 = Union{Float16,U2}
+    @test DD.type_instability(U2) == true
+    @test DD.type_instability_limit_unions(U2, Val(2)) == false
+    # Limit will also apply to tuples:
+    @test DD.type_instability(Tuple{U2,Bool}) == true
+    @test DD.type_instability_limit_unions(Tuple{U2,Bool}, Val(2)) == false
+
+    # Multiple unions – only max union split taken:
+    @test DD.type_instability_limit_unions(Tuple{U2,U2,Bool}, Val(2)) == false
+    @test DD.type_instability_limit_unions(Tuple{U2,U2,Bool}, Val(2)) == false
+    @test DD.type_instability_limit_unions(Tuple{U2,U3,Bool}, Val(2)) == true
+
+    # TypeVar should still be unstable
+    @test DD.type_instability_limit_unions(Tuple{U2,T} where {T}, Val(2)) == true
+end
 @testitem "skip global" begin
     using DispatchDoctor
     @stable struct A


### PR DESCRIPTION
Fixes an edgecase where a return type `Tuple{Union{A,B,C}}` would not respect the user-provided `union_limit`. This fixes it by adding special treatment for tuple types.

Note that this does not apply to any other struct. It just seems that tuples get special treatment by the compiler:

```julia
julia> struct A{T}
           a::T
       end

julia> Base.isconcretetype(Union{Float32,Float64})
false

julia> Base.isconcretetype(Tuple{Union{Float32,Float64}})
false

julia> Base.isconcretetype(A{Union{Float32,Float64}})
true
```