### PR TITLE
Skip `getproperty` and `setproperty!`

### DIFF
--- a/src/macro_interactions.jl
+++ b/src/macro_interactions.jl
@@ -110,7 +110,7 @@ end
 
 Globally ignore certain functions when stabilizing.
 By default, a few functions in Base are ignored, as they are meant to
-be unstable, and will be inlined by the compiler.
+be unstable, and will (hopefully) always be inlined by the compiler.
 """
 @inline ignore_function(f) = false
 @inline function ignore_function(

--- a/src/macro_interactions.jl
+++ b/src/macro_interactions.jl
@@ -113,8 +113,10 @@ By default, a few functions in Base are ignored, as they are meant to
 be unstable, and will be inlined by the compiler.
 """
 @inline ignore_function(f) = false
-@inline ignore_function(::typeof(iterate)) = true
-@inline ignore_function(::typeof(getproperty)) = true
-@inline ignore_function(::typeof(setproperty!)) = true
+@inline function ignore_function(
+    ::Union{map(typeof, (iterate, getproperty, setproperty!))...}
+)
+    return true
+end
 
 end

--- a/src/macro_interactions.jl
+++ b/src/macro_interactions.jl
@@ -109,9 +109,12 @@ end
     ignore_function(f)
 
 Globally ignore certain functions when stabilizing.
-By default, `Base.iterate` is ignored, as it is meant to be unstable.
+By default, a few functions in Base are ignored, as they are meant to
+be unstable, and will be inlined by the compiler.
 """
 @inline ignore_function(f) = false
 @inline ignore_function(::typeof(iterate)) = true
+@inline ignore_function(::typeof(getproperty)) = true
+@inline ignore_function(::typeof(setproperty!)) = true
 
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -820,7 +820,7 @@ end
         end
     end
 end
-@testitem "skip Base.iterate" begin
+@testitem "skip certain functions" begin
     using DispatchDoctor
     using DispatchDoctor: _Interactions as DDI
 
@@ -829,12 +829,16 @@ end
 
     struct MyTypeIterate end
     @stable begin
-        f(x) = x > 0 ? x : 0.0
-        Base.iterate(::MyTypeIterate) = (1, 1)
+        f() = Val(rand())
+        Base.iterate(::MyTypeIterate) = Val(rand())
+        Base.getproperty(::MyTypeIterate, ::Symbol) = Val(rand())
+        Base.setproperty!(::MyTypeIterate, ::Symbol, _) = Val(rand())
     end
     if DispatchDoctor.JULIA_OK
-        @test_throws TypeInstabilityError f(0)
-        @test iterate(MyTypeIterate()) == (1, 1)
+        @test_throws TypeInstabilityError f()
+        @test iterate(MyTypeIterate()) isa Val
+        @test getproperty(MyTypeIterate(), :x) isa Val
+        @test setproperty!(MyTypeIterate(), :x, 1) isa Val
     end
 end
 @testitem "conditionally allow union instabilities" begin


### PR DESCRIPTION
Currently we just skip `iterate` but not also `getproperty` and `setproperty!`.

These functions are meant to be unstable with respect to input argument (just a symbol) and will (hopefully) always be inlined by the compiler. So this special cases them.