### PR TITLE
fix zygote incompatibility with warnings

### DIFF
--- a/ext/DispatchDoctorChainRulesCoreExt.jl
+++ b/ext/DispatchDoctorChainRulesCoreExt.jl
@@ -1,8 +1,11 @@
 module DispatchDoctorChainRulesCoreExt
 
-using ChainRulesCore: @ignore_derivatives
+using ChainRulesCore: @ignore_derivatives, @non_differentiable
 import DispatchDoctor._Errors: show_warning, TypeInstabilityWarning
+import DispatchDoctor._Stabilization: _construct_pairs
 
 show_warning(w::TypeInstabilityWarning, ::Int) = (@ignore_derivatives(@warn w); nothing)
+
+@non_differentiable _construct_pairs(::Any...)
 
 end

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -185,6 +185,8 @@ function _stabilize_module(ex, downward_metadata; kws...)
     )
 end
 
+_construct_pairs(x, y) = x .=> y
+
 function _stabilize_fnc(
     fex::Expr,
     downward_metadata::DownwardMetadata;
@@ -243,7 +245,7 @@ function _stabilize_fnc(
                 $(source_info),
                 ($(arg_symbols...),),
                 (; $(kwarg_symbols...)),
-                ($(where_param_symbols) .=> ($(where_param_symbols...),)),
+                ($(_construct_pairs)($(where_param_symbols), ($(where_param_symbols...),))),
                 $T,
             ),
         ))
@@ -254,7 +256,7 @@ function _stabilize_fnc(
                 $(source_info),
                 ($(arg_symbols...),),
                 (; $(kwarg_symbols...)),
-                ($(where_param_symbols) .=> ($(where_param_symbols...),)),
+                ($(_construct_pairs)($(where_param_symbols), ($(where_param_symbols...),))),
                 $T,
             ),
             0,

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -1,5 +1,5 @@
 """Test that `@stable` is compatible with Zygote"""
-module EnzymeTest
+module ZygoteTest
 
 using DispatchDoctor: @stable, TypeInstabilityError
 using Zygote: gradient
@@ -13,7 +13,6 @@ using Test
 # Still want errors to show up:
 @stable default_mode = "error" g(x) = x > 0 ? x : 0
 @test_skip false
-@test_throws ErrorException gradient(g, 1.0)
-# TODO: How to get this to return the right error?
+@test_throws TypeInstabilityError gradient(g, 1.0)
 
 end


### PR DESCRIPTION
The `show_warning` can also be written as

```julia
@non_differentiable show_warning(::Any...)
```

for consistency.