### PR TITLE
AirspeedVelocity.jl CI + Benchmarks

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,0 +1,69 @@
+name: Benchmark a pull request
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+    generate_plots:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v2
+              with:
+                version: "1"
+            - uses: julia-actions/cache@v2
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --exeflags="-O3 --threads=auto"
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                echo '### Benchmark Plots' >> body.md
+                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v3
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
+
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,5 @@
 using BenchmarkTools
-using DispatchDoctor: _stabilize_all
+using DispatchDoctor: _stable
 
 const SUITE = BenchmarkGroup()
 
@@ -23,13 +23,13 @@ ex = quote
     end
 end
 
-module EmptyModule
+@eval module EmptyModule
 end
 
 for mode in ("error", "warn", "disable")
     options = Any[:(default_mode=$mode)]
     SUITE["_stable"]["mode=$mode"] = @benchmarkable(
-        $_stable(ex, options; calling_module, source_info=nothing),
+        $(_stable)(ex, options; calling_module, source_info=nothing),
         setup=(ex=$ex; options=$options; calling_module=EmptyModule)
     )
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,35 @@
+using BenchmarkTools
+using DispatchDoctor: _stabilize_all
+
+const SUITE = BenchmarkGroup()
+
+ex = quote
+    f() = rand(Bool) ? 0 : 1.0
+    f(x) = x
+
+    module A
+        function g(; a, b)
+            return a + b
+        end
+
+        module B
+            using DispatchDoctor: @unstable
+            @unstable h() = rand(Bool) ? 0 : 1.0
+
+            @unstable begin
+                h(x::Int) = rand(Bool) ? 0 : 1.0
+            end
+        end
+    end
+end
+
+module EmptyModule
+end
+
+for mode in ("error", "warn", "disable")
+    options = Any[:(default_mode=$mode)]
+    SUITE["_stable"]["mode=$mode"] = @benchmarkable(
+        $_stable(ex, options; calling_module, source_info=nothing),
+        setup=(ex=$ex; options=$options; calling_module=EmptyModule)
+    )
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,5 @@
 using BenchmarkTools
-using DispatchDoctor: _stable
+using DispatchDoctor: DispatchDoctor, _stable
 
 const SUITE = BenchmarkGroup()
 
@@ -23,13 +23,10 @@ ex = quote
     end
 end
 
-@eval module EmptyModule
-end
-
 for mode in ("error", "warn", "disable")
     options = Any[:(default_mode=$mode)]
     SUITE["_stable"]["mode=$mode"] = @benchmarkable(
-        $(_stable)(ex, options; calling_module, source_info=nothing),
-        setup=(ex=$ex; options=$options; calling_module=EmptyModule)
+        $(_stable)(ex, options; calling_module=nothing, source_info=nothing),
+        setup=(ex=$ex; options=$options)
     )
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,27 +6,23 @@ const SUITE = BenchmarkGroup()
 ex = quote
     f() = rand(Bool) ? 0 : 1.0
     f(x) = x
-
     module A
-        function g(; a, b)
-            return a + b
-        end
+    function g(; a, b)
+        return a + b
+    end
 
-        module B
-            using DispatchDoctor: @unstable
-            @unstable h() = rand(Bool) ? 0 : 1.0
-
-            @unstable begin
-                h(x::Int) = rand(Bool) ? 0 : 1.0
-            end
+    module B
+        $(DispatchDoctor).@unstable begin
+            h() = rand(Bool) ? 0 : 1.0
         end
+    end
     end
 end
 
 for mode in ("error", "warn", "disable")
-    options = Any[:(default_mode=$mode)]
+    options = Any[:(default_mode = $mode)]
     SUITE["_stable"]["mode=$mode"] = @benchmarkable(
-        $(_stable)(ex, options; calling_module=nothing, source_info=nothing),
-        setup=(ex=$ex; options=$options)
+        $_stable(options..., ex; calling_module=nothing, source_info=nothing),
+        setup = (ex = $(QuoteNode(ex)); options = $options)
     )
 end


### PR DESCRIPTION
Just so we can monitor that the macro itself stays speedy and also that load time doesn't increase (especially for `default_mode="disable"` which people will use in packages)