### PR TITLE
Cached access to Preferences.jl

### DIFF
--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -71,10 +71,7 @@ end
 function get_all_preferred(options::StabilizationOptions, calling_module)
     return StabilizationOptions(
         get_preferred(
-            options.mode,
-            PREFERENCE_CACHE.mode,
-            calling_module,
-            "instability_check"
+            options.mode, PREFERENCE_CACHE.mode, calling_module, "instability_check"
         ),
         get_preferred(
             options.codegen_level,

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -30,6 +30,7 @@ const PREFERENCE_CACHE = (;
     codegen_level=Cache{Base.UUID,Tuple{String,IsCached}}(),
     union_limit=Cache{Base.UUID,Tuple{Int,IsCached}}(),
 )
+# All of our preferences are compile-time only, so we can safely cache them
 
 function _cached_call(f::F, cache::Cache, key) where {F}
     lock(cache.lock) do
@@ -51,7 +52,6 @@ end
 function get_preferred(default, cache, calling_module, key, deprecated_key=nothing)
     uuid = _cached_get_uuid(calling_module)
     # ^Surprisingly it takes 600 us to get the UUID, so its worth the cache!
-    # Note that all of our preferences are compile-time only, so we can safely cache them
     # TODO: Though, this might need to be changed if Revise.jl becomes compatible
     (value, cached) = _cached_call(cache, uuid) do
         if has_preference(uuid, key)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -69,10 +69,15 @@ function get_preferred(default, cache, calling_module, key, deprecated_key=nothi
     end
 end
 function get_all_preferred(options::StabilizationOptions, calling_module)
+    mode = get_preferred(
+        options.mode, PREFERENCE_CACHE.mode, calling_module, "instability_check"
+    )
+    if mode == "disable"
+        # Short circuit and quit early
+        return StabilizationOptions("disable", options.codegen_level, options.union_limit)
+    end
     return StabilizationOptions(
-        get_preferred(
-            options.mode, PREFERENCE_CACHE.mode, calling_module, "instability_check"
-        ),
+        mode,
         get_preferred(
             options.codegen_level,
             PREFERENCE_CACHE.codegen_level,

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -13,32 +13,60 @@ const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
 const GLOBAL_DEFAULT_UNION_LIMIT = 1
 
-# (Just so we can test with custom UUID types)
-uuid_type(_) = Base.UUID
+Base.@kwdef struct Cache{A,B}
+    cache::Dict{A,B} = Dict{A,B}()
+    lock::Threads.SpinLock = Threads.SpinLock()
+end
+const UUID_CACHE = Cache{UInt64,Base.UUID}()
+const HAS_PREFERENCE_CACHE = Cache{Tuple{Base.UUID,String},Bool}()
+const PREFERENCE_CACHE = Cache{Tuple{Base.UUID,String},String}()
 
-function get_preferred(default, calling_module, key, deprecated_key=nothing)
-    try
-        uuid = get_uuid(calling_module)::uuid_type(calling_module)
-        if has_preference(uuid, key)
-            return load_preference(uuid, key, default)
-        elseif deprecated_key !== nothing && has_preference(uuid, deprecated_key)
-            return load_preference(uuid, deprecated_key, default)
-        else
-            return default
+function _cached_call(f::F, cache::Cache, key) where {F}
+    lock(cache.lock) do
+        get!(cache.cache, key) do
+            f()
         end
-    catch
-        default
     end
 end
-function get_all_preferred(options::StabilizationOptions, calling_module)
+# Surprisingly it takes 600 us to get the UUID, so its worth the cache!
+function _cached_get_uuid(m)
+    _cached_call(UUID_CACHE, objectid(m)) do
+        try
+            get_uuid(m)
+        catch
+            Base.UUID(0)
+        end
+    end
+end
+function _cached_has_preference(uuid, key)
+    _cached_call(HAS_PREFERENCE_CACHE, (uuid, key)) do
+        has_preference(uuid, key)
+    end
+end
+function _cached_load_preference(uuid, key)
+    _cached_call(PREFERENCE_CACHE, (uuid, key)) do
+        load_preference(uuid, key)
+    end
+end
+
+function get_preferred(default, calling_module, key, deprecated_key=nothing)
+    uuid = _cached_get_uuid(calling_module)
+    if _cached_has_preference(uuid, key)
+        return _cached_load_preference(uuid, key)
+    elseif deprecated_key !== nothing && _cached_has_preference(uuid, deprecated_key)
+        return _cached_load_preference(uuid, deprecated_key)
+    else
+        return default
+    end
+end
+function get_all_preferred(options::StabilizationOptions, m)
     #! format: off
     return StabilizationOptions(
-        get_preferred(options.mode, calling_module, "instability_check"),
-        get_preferred(options.codegen_level, calling_module, "instability_check_codegen_level", "instability_check_codegen"),
-        get_preferred(options.union_limit, calling_module, "instability_check_union_limit"),
+        get_preferred(options.mode, m, "instability_check"),
+        get_preferred(options.codegen_level, m, "instability_check_codegen_level", "instability_check_codegen"),
+        get_preferred(options.union_limit, m, "instability_check_union_limit"),
     )
     #! format: on
-    # TODO: formally deprecate "instability_check_codegen
 end
 
 end

--- a/test/FakePackage1/LocalPreferences.toml
+++ b/test/FakePackage1/LocalPreferences.toml
@@ -1,0 +1,4 @@
+[FakePackage1]
+instability_check = "a"
+instability_check_codegen_level = "b"
+instability_check_union_limit = 3

--- a/test/FakePackage1/Project.toml
+++ b/test/FakePackage1/Project.toml
@@ -1,0 +1,13 @@
+name = "FakePackage1"
+uuid = "9c6a4105-e713-43d4-8113-9b9a5020bb71"
+authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
+version = "1.0.0-DEV"
+
+[compat]
+julia = "1.6.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/FakePackage1/src/FakePackage1.jl
+++ b/test/FakePackage1/src/FakePackage1.jl
@@ -1,0 +1,5 @@
+module FakePackage1
+
+# Write your package code here.
+
+end

--- a/test/FakePackage2/LocalPreferences.toml
+++ b/test/FakePackage2/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[FakePackage2]
+instability_check_codegen = "alpha"

--- a/test/FakePackage2/Project.toml
+++ b/test/FakePackage2/Project.toml
@@ -1,0 +1,13 @@
+name = "FakePackage2"
+uuid = "7d4b04ae-8520-4e92-a646-6dc642468aac"
+authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
+version = "1.0.0-DEV"
+
+[compat]
+julia = "1.6.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/FakePackage2/src/FakePackage2.jl
+++ b/test/FakePackage2/src/FakePackage2.jl
@@ -1,0 +1,5 @@
+module FakePackage2
+
+# Write your package code here.
+
+end

--- a/test/FakePackage3/Project.toml
+++ b/test/FakePackage3/Project.toml
@@ -1,0 +1,13 @@
+name = "FakePackage3"
+uuid = "64ea69ba-22bc-4917-97b4-c93519e8787c"
+authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
+version = "1.0.0-DEV"
+
+[compat]
+julia = "1.6.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/FakePackage3/src/FakePackage3.jl
+++ b/test/FakePackage3/src/FakePackage3.jl
@@ -1,0 +1,5 @@
+module FakePackage3
+
+# Write your package code here.
+
+end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -949,61 +949,34 @@ end
     end
 end
 @testitem "Preferences.jl" begin
+    using DispatchDoctor
     import DispatchDoctor._Preferences as DDP
     import DispatchDoctor._ParseOptions as DDPO
-    import Preferences: load_preference, has_preference, get_uuid
+    import Preferences: set_preferences!, load_preference, has_preference, get_uuid
 
-    abstract type FakeUUID end
-    abstract type FakeModule end
-    struct FakeModule1 <: FakeModule end
-    struct FakeModule2 <: FakeModule end
-    struct FakeModule3 <: FakeModule end
-    struct FakeUUID1 <: FakeUUID end
-    struct FakeUUID2 <: FakeUUID end
-    struct FakeUUID3 <: FakeUUID end
+    push!(LOAD_PATH, joinpath(@__DIR__, "FakePackage1"))
+    push!(LOAD_PATH, joinpath(@__DIR__, "FakePackage2"))
+    push!(LOAD_PATH, joinpath(@__DIR__, "FakePackage3"))
 
-    # Default:
-    @test DDP.uuid_type(Core.Main) == Base.UUID
-    DDP.uuid_type(::FakeModule) = FakeUUID
-    get_uuid(::FakeModule1) = FakeUUID1()
-    get_uuid(::FakeModule2) = FakeUUID2()
-    function load_preference(::FakeUUID, k, default)
-        if k == "instability_check"
-            return "a"
-        elseif k == "instability_check_codegen"
-            return "b"
-        elseif k == "instability_check_codegen_level"
-            return "c"
-        elseif k == "instability_check_union_limit"
-            return 7
-        end
+    # These packages have `LocalPreferences.toml` with
+    # various settings
+    using FakePackage1
+
+    options = DDP.StabilizationOptions("d", "e", 6)
+    @test DDP.get_all_preferred(options, FakePackage1) ==
+        DDP.StabilizationOptions("a", "b", 3)
+
+    using FakePackage2
+    options = DDP.StabilizationOptions("d", "e", 6)
+    @test DDP.get_all_preferred(options, FakePackage2) ==
+        DDP.StabilizationOptions("d", "alpha", 6)
+
+    # FakePackage3 has no preferences
+    using FakePackage3
+    FakePackage3.eval(:($(DispatchDoctor).@stable f() = Val(rand())))
+    if DispatchDoctor.JULIA_OK
+        @test_throws TypeInstabilityError FakePackage3.f()
     end
-
-    options = DDP.StabilizationOptions("d", "e", 3)
-    m = FakeModule1()
-    # FakeModule 1 has all the keys:
-    has_preference(::FakeUUID1, k) = true
-    @test DDP.get_all_preferred(options, m) == DDP.StabilizationOptions("a", "c", 7)
-    # So it checks the `_codegen` key first^
-
-    # However, FakeModule2 is missing the `_codegen_level` key, and using
-    # the deprecated version:
-    m2 = FakeModule2()
-    has_preference(::FakeUUID2, k) = k != "instability_check_codegen_level"
-    @test DDP.get_all_preferred(options, m2) == DDP.StabilizationOptions("a", "b", 7)
-
-    # FakeModule3 takes the defaults for everything:
-    m3 = FakeModule3()
-    has_preference(::FakeUUID3, k) = false
-    options = DDP.StabilizationOptions("f", "g", 8)
-    @test DDP.get_all_preferred(options, m3) == options
-
-    # By default, passing Main will just return all the options:
-    @test DDPO.parse_options(Any[], Main) == DDP.StabilizationOptions(
-        DDP.GLOBAL_DEFAULT_MODE,
-        DDP.GLOBAL_DEFAULT_CODEGEN_LEVEL,
-        DDP.GLOBAL_DEFAULT_UNION_LIMIT,
-    )
 end
 @testitem "warn on no matches" begin
     using DispatchDoctor

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -131,7 +131,17 @@ end
         DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g(*, *)
     end
 end
+@testitem "QuoteNode in options" begin
+    using DispatchDoctor
+    using DispatchDoctor: _ParseOptions as DDPO
+    default_mode = "disable"
+    @eval @stable default_mode = $default_mode f() = Val(rand())
+    @test f() isa Val
+    @test DDPO._parse(QuoteNode(default_mode), String) == "disable"
 
+    # Edge case
+    @test DDPO._parse(nothing, String) == nothing
+end
 @testitem "showerror" begin
     using DispatchDoctor
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -987,6 +987,13 @@ end
     if DispatchDoctor.JULIA_OK
         @test_throws TypeInstabilityError FakePackage3.f()
     end
+
+    # By default, passing Main will just return all the options:
+    @test DDPO.parse_options(Any[], Main) == DDP.StabilizationOptions(
+        DDP.GLOBAL_DEFAULT_MODE,
+        DDP.GLOBAL_DEFAULT_CODEGEN_LEVEL,
+        DDP.GLOBAL_DEFAULT_UNION_LIMIT,
+    )
 end
 @testitem "warn on no matches" begin
     using DispatchDoctor

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -12,7 +12,6 @@ using Test
 
 # Still want errors to show up:
 @stable default_mode = "error" g(x) = x > 0 ? x : 0
-@test_skip false
 @test_throws TypeInstabilityError gradient(g, 1.0)
 
 end


### PR DESCRIPTION
Surprisingly it takes ~600 us to load from Preferences.jl. This seems to slow down package load times, **even if** `default_mode="disable"`. So this helps speed up Preferences.jl access via caching and an early exit if a `"disable"` is found.

Now it's **under 1 us**!