### PR TITLE
Fix: edge-case precompilation segfault on Julia 1.11

### DIFF
--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -267,7 +267,7 @@ function _stabilize_fnc(
         error("Unknown mode: $mode. Please use \"error\" or \"warn\".")
     end
 
-    typeof_args = Expr(:call, map_specializing_typeof, arg_symbols...)
+    typeof_args = :($(map_specializing_typeof)(($(arg_symbols...),)))
     infer = if isempty(kwarg_symbols)
         :($(_promote_op)($simulator, $(typeof_args)))
     else


### PR DESCRIPTION
This tiny change
```diff
-   typeof_args = Expr(:call, map_specializing_typeof, arg_symbols...)
+   typeof_args = :($(map_specializing_typeof)(($(arg_symbols...),)))
```

is enough to prevent one of those "Unreachable reached" errors in Julia precompilation – and only on Julia 1.11+. We should probably make a bug report to Julia about this, though I'm not sure I have bandwidth to package the error into a digestible MWE.

```
SymbolicRegression --code-coverage=@/home/runner/work/SymbolicRegression.jl/SymbolicRegression.jl --color=yes --check-bounds=yes --warn-overwrite=yes --depwarn=yes --inline=yes --startup-file=no --track-allocation=none 

Failed to precompile SymbolicRegression [8254be44-1295-4e6a-a16d-46603ac705cb] to "/home/runner/.julia/compiled/v1.11/SymbolicRegression/jl_G4yS0y".
Unreachable reached at 0x7f2162ad2df5

[5165] signal 4 (2): Illegal instruction
in expression starting at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/DynamicExpressions.jl:111
is_bad_array at /home/runner/.julia/packages/DispatchDoctor/eWFc7/src/stabilization.jl:301
##eval_tree_array_simulator#549#1 at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/Evaluate.jl:87 [inlined]
##eval_tree_array_simulator#549 at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/Evaluate.jl:66 [inlined]
#eval_tree_array#2 at /home/runner/.julia/packages/DispatchDoctor/eWFc7/src/stabilization.jl:306 [inlined]
eval_tree_array at /home/runner/.julia/packages/DispatchDoctor/eWFc7/src/stabilization.jl:301
unknown function (ip: 0x7f2162b0322d)
#test_all_combinations#1 at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:7
test_all_combinations at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:22 [inlined]
macro expansion at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:169 [inlined]
macro expansion at /home/runner/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:78 [inlined]
macro expansion at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:154 [inlined]
macro expansion at /home/runner/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:140 [inlined]
#do_precompilation#2 at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:139
do_precompilation at /home/runner/.julia/packages/DynamicExpressions/IF10i/src/precompile.jl:162
unknown function (ip: 0x7f2162acfea2)
```

cc @avik-pal 

Fixes #51 