### PR TITLE
Support type-constrained destructuring

### DIFF
--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -9,7 +9,7 @@ using .._Utils:
     _promote_op,
     is_function_name_compatible,
     get_first_source_info,
-    inject_symbol_to_arg,
+    sanitize_arg_for_stability_check,
     extract_symbol,
     type_instability,
     type_instability_limit_unions
@@ -228,7 +228,7 @@ function _stabilize_fnc(
     end
 
     args, destructurings = let
-        args_destructurings = map(inject_symbol_to_arg, func[:args])
+        args_destructurings = map(sanitize_arg_for_stability_check, func[:args])
         (
             map(first, args_destructurings),
             filter(!isnothing, map(last, args_destructurings)),

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -293,7 +293,7 @@ function _stabilize_fnc(
     caller = if codegen_level == "debug"
         # We duplicate entire body, so `@code_warntype` works
         body = func[:body]
-        # and we also destructure signature
+        # and we also destructure the signature
         Expr(:block, destructurings..., body)
     elseif isempty(kwarg_symbols)
         :($simulator($(arg_symbols...)))

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -227,9 +227,10 @@ function _stabilize_fnc(
         print_name = "anonymous function"
     end
 
-    args_destructurings = map(inject_symbol_to_arg, func[:args])
-    args = first.(args_destructurings)
-    destructurings = filter(!isnothing, last.(args_destructurings))
+    args, destructurings = let
+        args_destructurings = map(inject_symbol_to_arg, func[:args])
+        map(first, args_destructurings), map(last, args_destructurings)
+    end
     kwargs = func[:kwargs]
     where_params = func[:whereparams]
 
@@ -287,9 +288,10 @@ function _stabilize_fnc(
     end
 
     caller = if codegen_level == "debug"
-        # Duplicate entire body, so `@code_warntype` works
-        # Prepend destructuring expressions from signature
-        Expr(:block, destructurings..., func[:body])
+        # We duplicate entire body, so `@code_warntype` works
+        body = func[:body]
+        # and we also destructure signature
+        Expr(:block, destructurings..., body)
     elseif isempty(kwarg_symbols)
         :($simulator($(arg_symbols...)))
     else

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -229,7 +229,10 @@ function _stabilize_fnc(
 
     args, destructurings = let
         args_destructurings = map(inject_symbol_to_arg, func[:args])
-        map(first, args_destructurings), map(last, args_destructurings)
+        (
+            map(first, args_destructurings),
+            filter(!isnothing, map(last, args_destructurings)),
+        )
     end
     kwargs = func[:kwargs]
     where_params = func[:whereparams]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,10 +53,10 @@ end
 Fix args that do not have a symbol or are destructured in the signature. Return gensymmed
 arg expression and, if needed, an equivalent destructuring assignment for the body.
 """
-function inject_symbol_to_arg(ex::Symbol)
+function inject_symbol_to_arg(ex::Symbol)::Tuple{Union{Expr,Symbol},Union{Expr,Nothing}}
     return ex, nothing
 end
-function inject_symbol_to_arg(ex::Expr)
+function inject_symbol_to_arg(ex::Expr)::Tuple{Union{Expr,Symbol},Union{Expr,Nothing}}
     if ex.head == :(tuple)
         # Base case: matches things like (x,) and (; x)
         arg = gensym("arg")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -195,7 +195,7 @@ end
             )
             @eval @stable(
                 default_codegen_level = $codegen_level,
-                k(a, (; x, y)=(; z=a, x=2, y=3)) = x + y,
+                k(a, (; x, y)=(; z=1, x=a, y=3)) = x + y,
             )
             #! format: on
             @test f(S2(1, 2.0)) == 3.0
@@ -212,7 +212,7 @@ end
                 @test_throws TypeInstabilityError h([3, 4], U2(1, 2.0))
             DispatchDoctor.JULIA_OK &&
                 @test_throws TypeInstabilityError h(Any[3, 4], S2(1, 2.0))
-            @test k(nothing) == 5
+            @test k(1) == 4
             @test k(nothing, S2(1, 2.0)) == 3.0
             DispatchDoctor.JULIA_OK &&
                 @test_throws TypeInstabilityError k(nothing, U2(1, 2.0))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -55,10 +55,14 @@ end
 @testitem ":: tuple args" begin
     using DispatchDoctor
     for codegen_level in ("debug", "min")
-        fex = @eval @macroexpand @stable default_codegen_level = $codegen_level f((x,)::Vector) = x
+        fex = @eval @macroexpand @stable default_codegen_level = $codegen_level f(
+            (x,)::Vector
+        ) = x
         occursinf = occursin(string(fex))
         # Original signature preserved in simulator
-        @test occursinf(r"function var\"[#0-9]*f_simulator[#0-9]*\"\(\(x,\)::Vector[,; ]*\)$"m)
+        @test occursinf(
+            r"function var\"[#0-9]*f_simulator[#0-9]*\"\(\(x,\)::Vector[,; ]*\)$"m
+        )
         # Gensymmed arg used in new signature
         @test occursinf(r"function f\(var\"[#0-9]*arg[#0-9]*\"::Vector[,; ]*\)$"m)
         # Gensymmed arg used in instability check
@@ -68,7 +72,9 @@ end
             @test occursinf(r"\(x,\) = var\"[#0-9]*arg[#0-9]*\"$"m)
         else
             # Simulator called with gensymmed arg
-            @test occursinf(r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m)
+            @test occursinf(
+                r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m
+            )
         end
         @eval $fex
         @test f([1]) == 1
@@ -95,10 +101,14 @@ end
             y
         end
         for codegen_level in ("debug", "min")
-            gex = @eval @macroexpand @stable default_codegen_level = $codegen_level g((; x)::T) = x
+            gex = @eval @macroexpand @stable default_codegen_level = $codegen_level g(
+                (; x)::T
+            ) = x
             occursing = occursin(string(gex))
             # Original signature preserved in simulator
-            @test occursing(r"function var\"[#0-9]*g_simulator[#0-9]*\"\(\(; x\)::T[,; ]*\)$"m)
+            @test occursing(
+                r"function var\"[#0-9]*g_simulator[#0-9]*\"\(\(; x\)::T[,; ]*\)$"m
+            )
             # Gensymmed arg used in new signature
             @test occursing(r"function g\(var\"[#0-9]*arg[#0-9]*\"::T[,; ]*\)$"m)
             # Gensymmed arg used in instability check
@@ -108,7 +118,9 @@ end
                 @test occursing(r"\(; x\) = var\"[#0-9]*arg[#0-9]*\"$"m)
             else
                 # Simulator called with gensymmed arg
-                @test occursing(r"var\"[#0-9]*g_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m)
+                @test occursing(
+                    r"var\"[#0-9]*g_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m
+                )
             end
             @eval $gex
             @test g(S(1, 2.0)) == 1
@@ -122,19 +134,25 @@ end
                 x + y + z
             @test g3(S(1, 2.0), (; z=3)) == 6.0
             @test_throws MethodError g3((; x=1, y=2.0), (; z=3))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g3(U(1, 2.0), (; z=3))
-            @eval @stable default_codegen_level = $codegen_level g4((a, b)::Vector, (; x, y)::T) =
-                a + b + x + y
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError g3(U(1, 2.0), (; z=3))
+            @eval @stable default_codegen_level = $codegen_level g4(
+                (a, b)::Vector, (; x, y)::T
+            ) = a + b + x + y
             @test g4([3, 4], S(1, 2.0)) == 10.0
             @test_throws MethodError g4([3, 4], (; x=1, y=2.0))
             @test_throws MethodError g4((3, 4), S(1, 2.0))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g4([3, 4], U(1, 2.0))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g4(Any[3, 4], S(1, 2.0))
-            @eval @stable default_codegen_level = $codegen_level h(a, (; x, y) = (; z=a, x=2, y=3)) =
-                x + y
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError g4([3, 4], U(1, 2.0))
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError g4(Any[3, 4], S(1, 2.0))
+            @eval @stable default_codegen_level = $codegen_level h(
+                a, (; x, y)=(; z=a, x=2, y=3)
+            ) = x + y
             @test h(nothing) == 5
             @test h(nothing, S(1, 2.0)) == 3.0
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError h(nothing, U(1, 2.0))
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError h(nothing, U(1, 2.0))
         end
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -54,105 +54,168 @@ end
 end
 @testitem ":: tuple args" begin
     using DispatchDoctor
+
     for codegen_level in ("debug", "min")
-        fex = @eval @macroexpand @stable default_codegen_level = $codegen_level f(
-            (x,)::Vector
-        ) = x
-        occursinf = occursin(string(fex))
-        # Original signature preserved in simulator
-        @test occursinf(
-            r"function var\"[#0-9]*f_simulator[#0-9]*\"\(\(x,\)::Vector[,; ]*\)$"m
+        #! format: off
+        f_expanded = @eval @macroexpand @stable(
+            default_codegen_level = $codegen_level,
+            function f((x,)::Vector)
+                return x
+            end
         )
-        # Gensymmed arg used in new signature
-        @test occursinf(r"function f\(var\"[#0-9]*arg[#0-9]*\"::Vector[,; ]*\)$"m)
-        # Gensymmed arg used in instability check
-        @test occursinf(r"_promote_op.*var\"[#0-9]*arg[#0-9]*\"")
-        if codegen_level == "debug"
-            # Destructuring assignment in body
-            @test occursinf(r"\(x,\) = var\"[#0-9]*arg[#0-9]*\"$"m)
-        else
-            # Simulator called with gensymmed arg
-            @test occursinf(
-                r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m
-            )
+        #! format: on
+
+        expected_code_snippets = [
+            # Original signature preserved in simulator:
+            r"function var\"[#0-9]*f_simulator[#0-9]*\"\(\(x,\)::Vector[,; ]*\)$"m,
+            # Gensymmed arg used in new signature:
+            r"function f\(var\"[#0-9]*arg[#0-9]*\"::Vector[,; ]*\)$"m,
+            # Gensymmed arg used in instability check:
+            r"_promote_op.*var\"[#0-9]*arg[#0-9]*\"",
+        ]
+
+        # Destructuring assignment in body:
+        codegen_level == "debug" &&
+            push!(expected_code_snippets, r"\(x,\) = var\"[#0-9]*arg[#0-9]*\"$"m)
+
+        # Simulator called with gensymmed arg
+        codegen_level == "min" && push!(
+            expected_code_snippets,
+            r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m,
+        )
+
+        for expected_code in expected_code_snippets
+            @test occursin(expected_code, string(f_expanded))
         end
-        @eval $fex
+
+        eval(f_expanded)
+
         @test f([1]) == 1
         @test_throws MethodError f((1,)) == 1
         DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(Any[1])
-        @eval @stable default_codegen_level = $codegen_level f2((x, y)::Vector) = x + y
-        @test f2([1, 2]) == 3
-        @test_throws MethodError f2((1, 2))
-        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f2(Any[1, 2])
-        @eval @stable default_codegen_level = $codegen_level f3((x, y)::Vector, (z,)) =
-            x + y + z
-        @test f3([1, 2], (3,)) == 6
-        @test_throws MethodError f3((1, 2), (3,))
-        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f3(Any[1, 2], (3,))
     end
+end
+@testitem "multiple tuple args" begin
+    using DispatchDoctor
+
+    for codegen_level in ("debug", "min")
+        #! format: off
+        @eval @stable(
+            default_codegen_level = $codegen_level,
+            f((x, y)::Vector) = x + y,
+        )
+        @eval @stable(
+            default_codegen_level = $codegen_level,
+            g((x, y)::Vector, (z,)) = x + y + z,
+        )
+        #! format: on
+
+        @test f([1, 2]) == 3
+        @test_throws MethodError f((1, 2))
+        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(Any[1, 2])
+
+        @test g([1, 2], (3,)) == 6
+        @test_throws MethodError g((1, 2), (3,))
+        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g(Any[1, 2], (3,))
+    end
+end
+@testitem "property destructuring" begin
+    using DispatchDoctor
+
     if v"1.7-" <= VERSION  # property destructuring introduced in 1.7
-        abstract type T end
-        struct S <: T
+        abstract type MyAbstractType end
+        struct S <: MyAbstractType
             x::Int
             y::Float64
         end
-        struct U <: T
+        struct U <: MyAbstractType
             x
             y
         end
         for codegen_level in ("debug", "min")
-            gex = @eval @macroexpand @stable default_codegen_level = $codegen_level g(
-                (; x)::T
-            ) = x
-            occursing = occursin(string(gex))
-            # Original signature preserved in simulator
-            @test occursing(
-                r"function var\"[#0-9]*g_simulator[#0-9]*\"\(\(; x\)::T[,; ]*\)$"m
+            #! format: off
+            fex = @eval @macroexpand @stable(
+                default_codegen_level = $codegen_level,
+                f((; x)::MyAbstractType) = x
             )
-            # Gensymmed arg used in new signature
-            @test occursing(r"function g\(var\"[#0-9]*arg[#0-9]*\"::T[,; ]*\)$"m)
-            # Gensymmed arg used in instability check
-            @test occursing(r"_promote_op.*var\"[#0-9]*arg[#0-9]*\"")
-            if codegen_level == "debug"
-                # Destructuring assignment in body
-                @test occursing(r"\(; x\) = var\"[#0-9]*arg[#0-9]*\"$"m)
-            else
-                # Simulator called with gensymmed arg
-                @test occursing(
-                    r"var\"[#0-9]*g_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m
-                )
+            #! format: on
+
+            expected_code_snippets = [
+                # Original signature preserved in simulator
+                r"function var\"[#0-9]*f_simulator[#0-9]*\"\(\(; x\)::MyAbstractType[,; ]*\)$"m,
+                # Gensymmed arg used in new signature
+                r"function f\(var\"[#0-9]*arg[#0-9]*\"::MyAbstractType[,; ]*\)$"m,
+                # Gensymmed arg used in instability check
+                r"_promote_op.*var\"[#0-9]*arg[#0-9]*\"",
+            ]
+            codegen_level == "debug" &&
+                push!(expected_code_snippets, r"\(; x\) = var\"[#0-9]*arg[#0-9]*\"$"m)
+            codegen_level == "min" && push!(
+                expected_code_snippets,
+                r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m,
+            )
+
+            for expected_code in expected_code_snippets
+                @test occursin(expected_code, string(fex))
             end
-            @eval $gex
-            @test g(S(1, 2.0)) == 1
-            @test_throws MethodError g((; x=1))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g(U(1, 2.0))
-            @eval @stable default_codegen_level = $codegen_level g2((; x, y)::T) = x + y
-            @test g2(S(1, 2.0)) == 3.0
-            @test_throws MethodError g2((; x=1, y=2.0))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g2(U(1, 2.0))
-            @eval @stable default_codegen_level = $codegen_level g3((; x, y)::T, (; z)) =
-                x + y + z
-            @test g3(S(1, 2.0), (; z=3)) == 6.0
-            @test_throws MethodError g3((; x=1, y=2.0), (; z=3))
+
+            eval(fex)
+            @test f(S(1, 2.0)) == 1
+            @test_throws MethodError f((; x=1))
+            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(U(1, 2.0))
+        end
+    end
+end
+@testitem "multiple property destructuring" begin
+    using DispatchDoctor
+
+    if v"1.7-" <= VERSION  # property destructuring introduced in 1.7
+        abstract type MyAbstractType2 end
+        struct S2 <: MyAbstractType2
+            x::Int
+            y::Float64
+        end
+        struct U2 <: MyAbstractType2
+            x
+            y
+        end
+        for codegen_level in ("debug", "min")
+            #! format: off
+            @eval @stable(
+                default_codegen_level = $codegen_level,
+                f((; x, y)::MyAbstractType2) = x + y,
+            )
+            @eval @stable(
+                default_codegen_level = $codegen_level,
+                g((; x, y)::MyAbstractType2, (; z)) = x + y + z,
+            )
+            @eval @stable(
+                default_codegen_level = $codegen_level,
+                h((a, b)::Vector, (; x, y)::MyAbstractType2) = a + b + x + y,
+            )
+            @eval @stable(
+                default_codegen_level = $codegen_level,
+                k(a, (; x, y)=(; z=a, x=2, y=3)) = x + y,
+            )
+            #! format: on
+            @test f(S2(1, 2.0)) == 3.0
+            @test_throws MethodError f((; x=1, y=2.0))
+            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(U2(1, 2.0))
+            @test g(S2(1, 2.0), (; z=3)) == 6.0
+            @test_throws MethodError g((; x=1, y=2.0), (; z=3))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError g3(U(1, 2.0), (; z=3))
-            @eval @stable default_codegen_level = $codegen_level g4(
-                (a, b)::Vector, (; x, y)::T
-            ) = a + b + x + y
-            @test g4([3, 4], S(1, 2.0)) == 10.0
-            @test_throws MethodError g4([3, 4], (; x=1, y=2.0))
-            @test_throws MethodError g4((3, 4), S(1, 2.0))
+                @test_throws TypeInstabilityError g(U2(1, 2.0), (; z=3))
+            @test h([3, 4], S2(1, 2.0)) == 10.0
+            @test_throws MethodError h([3, 4], (; x=1, y=2.0))
+            @test_throws MethodError h((3, 4), S2(1, 2.0))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError g4([3, 4], U(1, 2.0))
+                @test_throws TypeInstabilityError h([3, 4], U2(1, 2.0))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError g4(Any[3, 4], S(1, 2.0))
-            @eval @stable default_codegen_level = $codegen_level h(
-                a, (; x, y)=(; z=a, x=2, y=3)
-            ) = x + y
-            @test h(nothing) == 5
-            @test h(nothing, S(1, 2.0)) == 3.0
+                @test_throws TypeInstabilityError h(Any[3, 4], S2(1, 2.0))
+            @test k(nothing) == 5
+            @test k(nothing, S2(1, 2.0)) == 3.0
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError h(nothing, U(1, 2.0))
+                @test_throws TypeInstabilityError k(nothing, U2(1, 2.0))
         end
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -52,6 +52,25 @@ end
         DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError h(1; y=2.0)
     end
 end
+@testitem ":: tuple args" begin
+    using DispatchDoctor
+    abstract type A end
+    struct B <: A
+        x::Int
+    end
+    struct C <: A
+        x
+    end
+    for codegen_level in ("debug", "min")
+        @eval @stable default_codegen_level = $codegen_level f((x,)::Vector) = x
+        @test f([1]) == 1
+        @test_throws MethodError f((1,)) == 1
+        @eval @stable default_codegen_level = $codegen_level g((; x)::A) = x
+        @test g(B(1)) == 1
+        @test_throws MethodError g((; x=1))
+        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g(C(1.0))
+    end
+end
 @testitem "Type specialization" begin
     using DispatchDoctor
     for codegen_level in ("debug", "min")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -84,7 +84,7 @@ end
             r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m,
         )
 
-        for expected_code in expected_code_snippets
+        DispatchDoctor.JULIA_OK && for expected_code in expected_code_snippets
             @test occursin(expected_code, string(f_expanded))
         end
 
@@ -124,11 +124,11 @@ end
 
     if v"1.7-" <= VERSION  # property destructuring introduced in 1.7
         abstract type MyAbstractType end
-        struct S <: MyAbstractType
+        struct StableType <: MyAbstractType
             x::Int
             y::Float64
         end
-        struct U <: MyAbstractType
+        struct UnstableType <: MyAbstractType
             x
             y
         end
@@ -155,14 +155,15 @@ end
                 r"var\"[#0-9]*f_simulator[#0-9]*\"\(var\"[#0-9]*arg[#0-9]*\"[,; ]*\)$"m,
             )
 
-            for expected_code in expected_code_snippets
+            DispatchDoctor.JULIA_OK && for expected_code in expected_code_snippets
                 @test occursin(expected_code, string(fex))
             end
 
             eval(fex)
-            @test f(S(1, 2.0)) == 1
+            @test f(StableType(1, 2.0)) == 1
             @test_throws MethodError f((; x=1))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(U(1, 2.0))
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError f(UnstableType(1, 2.0))
         end
     end
 end
@@ -171,11 +172,11 @@ end
 
     if v"1.7-" <= VERSION  # property destructuring introduced in 1.7
         abstract type MyAbstractType2 end
-        struct S2 <: MyAbstractType2
+        struct StableType2 <: MyAbstractType2
             x::Int
             y::Float64
         end
-        struct U2 <: MyAbstractType2
+        struct UnstableType2 <: MyAbstractType2
             x
             y
         end
@@ -198,24 +199,25 @@ end
                 k(a, (; x, y)=(; z=1, x=a, y=3)) = x + y,
             )
             #! format: on
-            @test f(S2(1, 2.0)) == 3.0
+            @test f(StableType2(1, 2.0)) == 3.0
             @test_throws MethodError f((; x=1, y=2.0))
-            DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(U2(1, 2.0))
-            @test g(S2(1, 2.0), (; z=3)) == 6.0
+            DispatchDoctor.JULIA_OK &&
+                @test_throws TypeInstabilityError f(UnstableType2(1, 2.0))
+            @test g(StableType2(1, 2.0), (; z=3)) == 6.0
             @test_throws MethodError g((; x=1, y=2.0), (; z=3))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError g(U2(1, 2.0), (; z=3))
-            @test h([3, 4], S2(1, 2.0)) == 10.0
+                @test_throws TypeInstabilityError g(UnstableType2(1, 2.0), (; z=3))
+            @test h([3, 4], StableType2(1, 2.0)) == 10.0
             @test_throws MethodError h([3, 4], (; x=1, y=2.0))
-            @test_throws MethodError h((3, 4), S2(1, 2.0))
+            @test_throws MethodError h((3, 4), StableType2(1, 2.0))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError h([3, 4], U2(1, 2.0))
+                @test_throws TypeInstabilityError h([3, 4], UnstableType2(1, 2.0))
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError h(Any[3, 4], S2(1, 2.0))
+                @test_throws TypeInstabilityError h(Any[3, 4], UnstableType2(1, 2.0))
             @test k(1) == 4
-            @test k(nothing, S2(1, 2.0)) == 3.0
+            @test k(nothing, StableType2(1, 2.0)) == 3.0
             DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError k(nothing, U2(1, 2.0))
+                @test_throws TypeInstabilityError k(nothing, UnstableType2(1, 2.0))
         end
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -111,12 +111,15 @@ end
         #! format: on
 
         @test f([1, 2]) == 3
-        @test_throws MethodError f((1, 2))
-        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(Any[1, 2])
-
         @test g([1, 2], (3,)) == 6
+
+        @test_throws MethodError f((1, 2))
         @test_throws MethodError g((1, 2), (3,))
-        DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError g(Any[1, 2], (3,))
+
+        if DispatchDoctor.JULIA_OK
+            @test_throws TypeInstabilityError f(Any[1, 2])
+            @test_throws TypeInstabilityError g(Any[1, 2], (3,))
+        end
     end
 end
 @testitem "property destructuring" begin
@@ -199,25 +202,25 @@ end
                 k(a, (; x, y)=(; z=1, x=a, y=3)) = x + y,
             )
             #! format: on
+
             @test f(StableType2(1, 2.0)) == 3.0
-            @test_throws MethodError f((; x=1, y=2.0))
-            DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError f(UnstableType2(1, 2.0))
             @test g(StableType2(1, 2.0), (; z=3)) == 6.0
-            @test_throws MethodError g((; x=1, y=2.0), (; z=3))
-            DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError g(UnstableType2(1, 2.0), (; z=3))
             @test h([3, 4], StableType2(1, 2.0)) == 10.0
-            @test_throws MethodError h([3, 4], (; x=1, y=2.0))
-            @test_throws MethodError h((3, 4), StableType2(1, 2.0))
-            DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError h([3, 4], UnstableType2(1, 2.0))
-            DispatchDoctor.JULIA_OK &&
-                @test_throws TypeInstabilityError h(Any[3, 4], UnstableType2(1, 2.0))
             @test k(1) == 4
             @test k(nothing, StableType2(1, 2.0)) == 3.0
-            DispatchDoctor.JULIA_OK &&
+
+            @test_throws MethodError f((; x=1, y=2.0))
+            @test_throws MethodError g((; x=1, y=2.0), (; z=3))
+            @test_throws MethodError h([3, 4], (; x=1, y=2.0))
+            @test_throws MethodError h((3, 4), StableType2(1, 2.0))
+
+            if DispatchDoctor.JULIA_OK
+                @test_throws TypeInstabilityError f(UnstableType2(1, 2.0))
+                @test_throws TypeInstabilityError g(UnstableType2(1, 2.0), (; z=3))
+                @test_throws TypeInstabilityError h([3, 4], UnstableType2(1, 2.0))
+                @test_throws TypeInstabilityError h(Any[3, 4], UnstableType2(1, 2.0))
                 @test_throws TypeInstabilityError k(nothing, UnstableType2(1, 2.0))
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes #54 

To manage the combinatorial explosion of composite argument expressions, I made `inject_symbol_to_arg` recursive, which means it now also supports `f((; x)::Foo...=foo) = ...` and other deeply cursed incantations. I didn't implement tests for such combinations, however.