### PR TITLE
docs: clean up printing of error type

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -6,7 +6,13 @@ using .._Errors: AllowUnstableDataRace, TypeInstabilityError, TypeInstabilityWar
 Base.showerror(io::IO, e::AllowUnstableDataRace) = print(io, e.msg)
 
 function _print_msg(io::IO, e::Union{TypeInstabilityError,TypeInstabilityWarning})
-    print(io, "$(typeof(e)): Instability detected in $(e.f)")
+    print(
+        io,
+        "DispatchDoctor.TypeInstability",
+        e isa TypeInstabilityError ? "Error" : "Warning",
+        ": Instability detected in ",
+        e.f,
+    )
     if e.source_info !== nothing
         print(io, " defined at ", e.source_info)
     end
@@ -25,7 +31,7 @@ function _print_msg(io::IO, e::Union{TypeInstabilityError,TypeInstabilityWarning
         join(io, parts, " and ")
     end
     print(io, ". ")
-    return print(io, "Inferred to be `$(e.return_type)`, which is not a concrete type.")
+    return print(io, "Inferred to be `", e.return_type, "`, which is not a concrete type.")
 end
 typeinfo(x) = specializing_typeof(x)
 typeinfo(u::Unknown) = u

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -618,7 +618,7 @@ end
 
     if DispatchDoctor.JULIA_OK
         msg = @capture_err f(1)
-        @test occursin("TypeInstabilityWarning", msg)
+        @test occursin("DispatchDoctor.TypeInstabilityWarning", msg)
     end
 end
 @testitem "disable @stable using env variable" begin
@@ -1192,7 +1192,7 @@ end
         @test occursin("The `warnonly` option is deprecated", msg)
         msg2 = @capture_err f(1)
 
-        @test occursin("TypeInstabilityWarning", msg2)
+        @test occursin("DispatchDoctor.TypeInstabilityWarning", msg2)
 
         @stable enable = false function f(x)
             return x > 0 ? x : 0.0


### PR DESCRIPTION
Very minor change that results in the error printing:
```
ERROR: DispatchDoctor.TypeInstabilityError: ...
```
rather than the current behavior which is:
```
ERROR: DispatchDoctor._Errors.TypeInstabilityError: ...
```