### PR TITLE
Fix underscore arguments with `codegen_level="min"`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,10 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.10.0'
+          - '1.10'
           - '1'
-          - '~1.11.0-0'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchDoctor"
 uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.4.15"
+version = "0.4.16"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ChainRulesCore = "1"
 EnzymeCore = "0.6, 0.7, 0.8"
 MacroTools = "0.5"
 Preferences = "1"
-julia = "1.6.7"
+julia = "1.10"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -56,7 +56,12 @@ arg expression and, if needed, an equivalent destructuring assignment for the bo
 function sanitize_arg_for_stability_check(
     ex::Symbol
 )::Tuple{Union{Expr,Symbol},Union{Expr,Nothing}}
-    return ex, nothing
+    if ex == :(_)
+        arg = gensym("arg")
+        return arg, Expr(:(=), ex, arg)
+    else
+        return ex, nothing
+    end
 end
 function sanitize_arg_for_stability_check(
     ex::Expr

--- a/test/dynamic_expressions.jl
+++ b/test/dynamic_expressions.jl
@@ -9,17 +9,23 @@ mktempdir() do tempdir
     run(`$(git()) clone $repo_url $dest_dir`)
     run(`$(git()) -C $dest_dir checkout v1.2.0`)
 
+    dd_path = dirname(dirname(@__FILE__))
+    dd_toml_content = TOML.parsefile(
+        joinpath(dd_path, "Project.toml")
+    )
+    dd_version = dd_toml_content["version"]
+
     # Modify compat in Project.toml
     project_toml_path = joinpath(dest_dir, "Project.toml")
     toml_content = TOML.parsefile(project_toml_path)
-    delete!(toml_content["compat"], "DispatchDoctor")
+    toml_content["compat"]["DispatchDoctor"] = "=$dd_version"
     open(project_toml_path, "w") do io
         TOML.print(io, toml_content)
     end
 
     # Activate the environment
     Pkg.activate(dest_dir)
-    Pkg.develop(; path=dirname(dirname(@__FILE__)))
+    Pkg.develop(; path=dd_path)
     Pkg.instantiate()
 
     # Run tests

--- a/test/dynamic_expressions.jl
+++ b/test/dynamic_expressions.jl
@@ -1,76 +1,27 @@
-"""Test that we can download DynamicExpressions and run the entirety of it."""
-
-using Git: git
+using Pkg
+using Git
 using TOML
 
-tempdir = mktempdir(; cleanup=false)
+mktempdir() do tempdir
+    # Clone DynamicExpressions.jl at version v1.2.0
+    repo_url = "https://github.com/SymbolicML/DynamicExpressions.jl.git"
+    dest_dir = joinpath(tempdir, "DynamicExpressions")
+    run(`$(git()) clone $repo_url $dest_dir`)
+    run(`$(git()) -C $dest_dir checkout v1.2.0`)
 
-# Define the repository URL
-repo_url = "https://github.com/SymbolicML/DynamicExpressions.jl.git"
-destination_folder = joinpath(tempdir, "DynamicExpressions")
-commit_sha = "ea0076e263e559467a3a5d11996cbddc7c08f36b"
-
-run(`$(git()) clone "$repo_url" "$destination_folder"`)
-run(`$(git()) -C "$destination_folder" checkout $commit_sha`)
-
-# Make edits to use DispatchDoctor:
-let
-    dynamic_expressions_path = joinpath(destination_folder, "src", "DynamicExpressions.jl")
-    contents = read(dynamic_expressions_path, String)
-    lines = split(contents, "\n")
-
-    insert!(lines, 2, "using DispatchDoctor: @stable, @unstable")
-    insert!(lines, 3, "@stable default_mode=\"warn\" begin")
-
-    # Find the index of the line to insert 'end' after 'include("Random.jl")'
-    index = findfirst(h -> occursin("include(\"Random.jl\")", h), lines)::Integer
-    insert!(lines, index + 1, "end")
-
-    new_contents = join(lines, "\n")
-    write(dynamic_expressions_path, new_contents)
-end
-
-# Make edits to tests
-let
-    test_path = joinpath(destination_folder, "test", "unittest.jl")
-    contents = read(test_path, String)
-    lines = split(contents, "\n")
-
-    # Comment out the line that includes "test_deprecations.jl"
-    index_deprecations =
-        findfirst(h -> occursin("include(\"test_deprecations.jl\")", h), lines)::Integer
-    lines[index_deprecations] = "# " * lines[index_deprecations]
-    # And test_evaluation.jl (weirdness in log test)
-    index_evaluation =
-        findfirst(h -> occursin("include(\"test_evaluation.jl\")", h), lines)::Integer
-    lines[index_evaluation] = "# " * lines[index_evaluation]
-
-    new_contents = join(lines, "\n")
-    write(test_path, new_contents)
-end
-
-# Add the current package
-let
-    dispatch_doctor_dir = dirname(dirname(@__FILE__))
-    julia_command_develop = Cmd([
-        "-e",
-        "using Pkg; Pkg.activate(\"$destination_folder\"); Pkg.develop(PackageSpec(path=\"$dispatch_doctor_dir\"))",
-    ])
-    run(`$(Base.julia_cmd()) $julia_command_develop`)
-
-    # Now, tweak the Project.toml to set the compat to 0.0.0-999.999.999:
-    project_toml_path = joinpath(destination_folder, "Project.toml")
-    project_toml = TOML.parsefile(project_toml_path)
-    project_toml["compat"]["DispatchDoctor"] = "0.0.0 - 999.999.999"
+    # Modify compat in Project.toml
+    project_toml_path = joinpath(dest_dir, "Project.toml")
+    toml_content = TOML.parsefile(project_toml_path)
+    delete!(toml_content["compat"], "DispatchDoctor")
     open(project_toml_path, "w") do io
-        TOML.print(io, project_toml)
+        TOML.print(io, toml_content)
     end
-end
 
-# Finally, run the test:
-let
-    julia_command_test = Cmd([
-        "-e", "using Pkg; Pkg.activate(\"$destination_folder\"); Pkg.test()"
-    ])
-    run(`$(Base.julia_cmd()) $julia_command_test`)
+    # Activate the environment
+    Pkg.activate(dest_dir)
+    Pkg.develop(; path=dirname(dirname(@__FILE__)))
+    Pkg.instantiate()
+
+    # Run tests
+    Pkg.test()
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -578,7 +578,7 @@ end
     @stable f(_) = rand(Bool) ? Float32 : Float64
     DispatchDoctor.JULIA_OK && @test_throws TypeInstabilityError f(1)
     if VERSION >= v"1.9"
-        @test_throws "with arguments `([_],)`" f(1)
+        @test_throws "with arguments `(Int64,)`" f(1)
     end
 end
 @testitem "skip closures inside macros" begin
@@ -1188,6 +1188,26 @@ end
     end
 
     @test f(2) == (nothing, 1)
+end
+@testitem "issue with underscore function and min codegen" begin
+    #! format: off
+    using DispatchDoctor
+
+    @stable g_debug(_::Int) = 1
+    @test g_debug(1) == 1
+    @stable default_codegen_level = "min" g_min(_::Int) = 1
+    @test g_min(1) == 1
+
+    @stable f_debug(_::Int, _::Float64) = 1
+    @test f_debug(1, 2.0) == 1
+    @stable default_codegen_level = "min" f_min(_::Int, _::Float64) = 1
+    @test f_min(1, 2.0) == 1
+
+    @stable default_codegen_level = "min" f_min_with_error(_::Int, _::Float64) = Val(rand())
+    if DispatchDoctor.JULIA_OK
+        @test_throws TypeInstabilityError f_min_with_error(1, 2.0)
+    end
+    # ! format: on
 end
 @testitem "deprecated options" begin
     using DispatchDoctor


### PR DESCRIPTION
This gets the following code to work correctly:

```julia
    @stable default_codegen_level = "min" g_min(_::Int) = 1
    @test g_min(1) == 1
```

It seems like the min codegen level was interfering with this.

This also deprecates Julia <1.10 because 1.9 and earlier are now unmaintained.