### PR TITLE
fix: avoid `@nospecialize` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchDoctor"
 uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.4.16"
+version = "0.4.17"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ you will also need to use `default_codegen_level="min"`.
 4. **Within certain code blocks and function types:**
     - Within an `@unstable` block
     - Within a `@generated` block
+    - Within any function containing a `@nospecialize` macro
 	- Within a `quote ... end` block
 	- Within a `macro ... end` block
 	- Within an incompatible macro, such as
 		- `@eval`
-		- `@generated`
 		- `@assume_effects`
 		- `@pure`
 		- Or anything else registered as incompatible with `register_macro!`

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -12,7 +12,8 @@ using .._Utils:
     sanitize_arg_for_stability_check,
     extract_symbol,
     type_instability,
-    type_instability_limit_unions
+    type_instability_limit_unions,
+    has_nospecialize
 using .._Errors: TypeInstabilityError, TypeInstabilityWarning
 using .._Interactions:
     ignore_function,
@@ -228,6 +229,12 @@ function _stabilize_fnc(
             filter(!isnothing, map(last, args_destructurings)),
         )
     end
+
+    # Check for @nospecialize anywhere in the original args or kwargs
+    if any(has_nospecialize, func[:args]) || any(has_nospecialize, func[:kwargs])
+        return fex, UpwardMetadata(downward_metadata)
+    end
+
     kwargs = func[:kwargs]
     where_params = func[:whereparams]
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -163,4 +163,15 @@ function _type_instability_recurse_unions(::Type{T}) where {T}
     end
 end
 
+"""
+Recursively search an expression for @nospecialize macro
+"""
+function has_nospecialize(ex::Expr)
+    if ex.head == :macrocall && ex.args[1] == Symbol("@nospecialize")
+        return true
+    end
+    return any(has_nospecialize, ex.args)
+end
+has_nospecialize(::Any) = false
+
 end

--- a/test/dynamic_expressions.jl
+++ b/test/dynamic_expressions.jl
@@ -10,9 +10,7 @@ mktempdir() do tempdir
     run(`$(git()) -C $dest_dir checkout v1.2.0`)
 
     dd_path = dirname(dirname(@__FILE__))
-    dd_toml_content = TOML.parsefile(
-        joinpath(dd_path, "Project.toml")
-    )
+    dd_toml_content = TOML.parsefile(joinpath(dd_path, "Project.toml"))
     dd_version = dd_toml_content["version"]
 
     # Modify compat in Project.toml


### PR DESCRIPTION
Fixes #59. Now `@nospecialize` methods are ignored.