### PR TITLE
fix: behavior for Core.TypeofBottom

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchDoctor"
 uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1241,6 +1241,11 @@ end
 
     @test DDU.is_function_name_compatible(1.0) == false
     @test DDU.is_symbol_like(1.0) == false
+
+    if Base.isdefined(Core, :TypeofBottom)
+        @test DD.type_instability(Core.TypeofBottom) == false
+        @test DD.type_instability_limit_unions(Core.TypeofBottom, Val(1)) == false
+    end
 end
 @testitem "Code quality (Aqua.jl)" begin
     using DispatchDoctor


### PR DESCRIPTION
This "Core.TypeofBottom" type in Julia came up as an edge case in SymbolicRegression.jl testing. We can better deal with such edge cases with the simple check `hasproperty(T, :types)` and otherwise fall back to `Base.isconcretetype`.