### PR TITLE
fix: deal with unbound args in signature

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,6 +108,7 @@ end
 # typeof but returns Type{T} for a type T input
 specializing_typeof(::T) where {T} = T
 specializing_typeof(::Type{T}) where {T} = Type{T}
+specializing_typeof(arg::Type{<:Type}) = typeof(arg)
 specializing_typeof(::Val{T}) where {T} = Val{T}
 map_specializing_typeof(args::Tuple) = map(specializing_typeof, args)
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1351,5 +1351,16 @@ end
     DispatchDoctor.JULIA_OK &&
         @test_throws TypeInstabilityError tuple_from_vector2([1, 2, 3])
 end
+@testitem "issue with specializing_typeof on unbound type parameters" begin
+    using DispatchDoctor
+
+    @stable function test_function(arg::Type{<:Type})
+        return nothing
+    end
+
+    # This should trigger the error
+    P = (Type{T} where {T}).body
+    @test test_function(P) === nothing
+end
 
 @run_package_tests


### PR DESCRIPTION
Dealing with https://github.com/JuliaLang/julia/issues/58899 weirdness