### PR TITLE
fix: issue with closures self-referencing

### DIFF
--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -302,7 +302,7 @@ function _stabilize_fnc(
         :($simulator($(arg_symbols...); $(kwarg_symbols...)))
     end
 
-    ignore = haskey(func, :name) ? :($(ignore_function)($(func[:name]))) : :(false)
+    ignore = haskey(func, :name) ? :($(ignore_function)(var"#self#")) : :(false)
 
     func_simulator[:name] = simulator
     func_simulator[:body] = if codegen_level == "debug"

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1362,5 +1362,16 @@ end
     P = (Type{T} where {T}).body
     @test test_function(P) === nothing
 end
+@testitem "issue with closures causing instability" begin
+    using DispatchDoctor
+
+    @stable function f(x)
+        @stable g() = x
+        return g
+    end
+
+    @test_nowarn f(1.0)()
+    @test f(1.0)() == 1.0
+end
 
 @run_package_tests


### PR DESCRIPTION
Basically due to the Julia boxing issue:

```julia
julia> using Test

julia> function f_recursive()
           function g(n)
               n <= 0 && return 1
               return n * g(n - 1)
           end
       end
f_recursive (generic function with 1 method)

julia> Test.@inferred f_recursive()
ERROR: return type var"#g#13" does not match inferred return type Any
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[8]:1
```

we see the same issue when using `@stable` on closure functions because we call

```julia
$(ignore_function)($(func[:name]))
```

So now we use `var"#self#"` to refer to the self function.