### PR TITLE
feat: create option to descend closure functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ you will also need to use `default_codegen_level="min"`.
 		- Or anything else registered as incompatible with `register_macro!`
 	- Parameterized functions like `MyType{T}(args...) = ...`
 	- Functions with an expression-based name like `(::MyType)(args...) = ...`
-	- A function inside another function (a closure).
+	- A function inside another function (a closure) - **unless `default_include_closures=true` is specified**.
 		- But note the outer function will still be stabilized. So, e.g., `@stable f(x) = map(xi -> xi^2, x)` would stabilize `f`, but not `xi -> xi^2`. Though if `xi -> xi^2` were unstable, `f` would likely be as well, and it would get caught!
+		- To also stabilize closures, use `@stable default_include_closures=true function f(x) ... end` or set `dispatch_doctor_include_closures=true` in your LocalPreferences.toml.
 
 Note that you can safely use `@stable` over all of these cases, and special cases will automatically be skipped. Although, if you use `@stable` internally in some of these cases, like calling `@stable` within a function on a closure, such as directly on the `xi -> xi^2`, then it can still apply.
 

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ you will also need to use `default_codegen_level="min"`.
 		- Or anything else registered as incompatible with `register_macro!`
 	- Parameterized functions like `MyType{T}(args...) = ...`
 	- Functions with an expression-based name like `(::MyType)(args...) = ...`
-	- A function inside another function (a closure) - **unless `default_include_closures=true` is specified**.
+	- A function inside another function (a closure) - **unless `default_closures=true` is specified**.
 		- But note the outer function will still be stabilized. So, e.g., `@stable f(x) = map(xi -> xi^2, x)` would stabilize `f`, but not `xi -> xi^2`. Though if `xi -> xi^2` were unstable, `f` would likely be as well, and it would get caught!
-		- To also stabilize closures, use `@stable default_include_closures=true function f(x) ... end` or set `dispatch_doctor_include_closures=true` in your LocalPreferences.toml.
+		- To also stabilize closures, use `@stable default_closures=true function f(x) ... end` or set `dispatch_doctor_closures=true` in your LocalPreferences.toml.
 
 Note that you can safely use `@stable` over all of these cases, and special cases will automatically be skipped. Although, if you use `@stable` internally in some of these cases, like calling `@stable` within a function on a closure, such as directly on the `xi -> xi^2`, then it can still apply.
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -22,6 +22,8 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 - `default_union_limit::Int=1`:
   - Sets the maximum elements in a union to be considered stable. The default is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}` is considered stable, but `Union{Float16,Float32,Float64}` is not.
   - To locally or globally override the union limit for a package that uses DispatchDoctor, you can use the `"dispatch_doctor_union_limit"` key in your LocalPreferences.toml.
+- `default_include_closures::Bool=false`:
+  - When set to `true`, the macro will also apply to closure functions defined within the stabilized code.
 
 
 # Example
@@ -54,7 +56,7 @@ which is not a concrete type.
 
 You may also apply `@stable` to arbitrary blocks of code, such as `begin`
 or `module`, and have it be applied to all functions.
-(Just note that this skips closure functions.)
+By default, this skips closure functions, but you can include them with `default_include_closures=true`.
 
 ```julia
 using DispatchDoctor: @stable

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -22,7 +22,7 @@ If type instability is detected, a `TypeInstabilityError` is thrown.
 - `default_union_limit::Int=1`:
   - Sets the maximum elements in a union to be considered stable. The default is `1`, meaning that all unions are considered unstable. A value of `2` would indicate that `Union{Float32,Float64}` is considered stable, but `Union{Float16,Float32,Float64}` is not.
   - To locally or globally override the union limit for a package that uses DispatchDoctor, you can use the `"dispatch_doctor_union_limit"` key in your LocalPreferences.toml.
-- `default_include_closures::Bool=false`:
+- `default_closures::Bool=false`:
   - When set to `true`, the macro will also apply to closure functions defined within the stabilized code.
 
 
@@ -56,7 +56,7 @@ which is not a concrete type.
 
 You may also apply `@stable` to arbitrary blocks of code, such as `begin`
 or `module`, and have it be applied to all functions.
-By default, this skips closure functions, but you can include them with `default_include_closures=true`.
+By default, this skips closure functions, but you can include them with `default_closures=true`.
 
 ```julia
 using DispatchDoctor: @stable

--- a/src/parse_options.jl
+++ b/src/parse_options.jl
@@ -6,6 +6,7 @@ using .._Preferences:
     GLOBAL_DEFAULT_MODE,
     GLOBAL_DEFAULT_CODEGEN_LEVEL,
     GLOBAL_DEFAULT_UNION_LIMIT,
+    GLOBAL_DEFAULT_INCLUDE_CLOSURES,
     StabilizationOptions
 
 function parse_options(options, calling_module)
@@ -13,6 +14,7 @@ function parse_options(options, calling_module)
     mode = GLOBAL_DEFAULT_MODE
     codegen_level = GLOBAL_DEFAULT_CODEGEN_LEVEL
     union_limit = GLOBAL_DEFAULT_UNION_LIMIT
+    include_closures = GLOBAL_DEFAULT_INCLUDE_CLOSURES
 
     # Deprecated
     warnonly = nothing
@@ -35,6 +37,9 @@ function parse_options(options, calling_module)
             elseif option.args[1] == :default_union_limit
                 union_limit = option.args[2]
                 continue
+            elseif option.args[1] == :default_include_closures
+                include_closures = option.args[2]
+                continue
             end
         end
         error("Unknown macro option: $option")
@@ -43,6 +48,7 @@ function parse_options(options, calling_module)
     mode = _parse_even_if_expr(mode, calling_module, String)
     codegen_level = _parse(codegen_level, String)
     union_limit = _parse(union_limit, Int)
+    include_closures = _parse(include_closures, Bool)
 
     _validate_mode(mode)
     _validate_codegen_level(codegen_level)
@@ -63,7 +69,7 @@ function parse_options(options, calling_module)
         mode
     end
 
-    options = StabilizationOptions(mode, codegen_level, union_limit)
+    options = StabilizationOptions(mode, codegen_level, union_limit, include_closures)
 
     if calling_module != Core.Main
         # Local setting from Preferences.jl overrides defaults

--- a/src/parse_options.jl
+++ b/src/parse_options.jl
@@ -6,7 +6,7 @@ using .._Preferences:
     GLOBAL_DEFAULT_MODE,
     GLOBAL_DEFAULT_CODEGEN_LEVEL,
     GLOBAL_DEFAULT_UNION_LIMIT,
-    GLOBAL_DEFAULT_INCLUDE_CLOSURES,
+    GLOBAL_DEFAULT_CLOSURES,
     StabilizationOptions
 
 function parse_options(options, calling_module)
@@ -14,7 +14,7 @@ function parse_options(options, calling_module)
     mode = GLOBAL_DEFAULT_MODE
     codegen_level = GLOBAL_DEFAULT_CODEGEN_LEVEL
     union_limit = GLOBAL_DEFAULT_UNION_LIMIT
-    include_closures = GLOBAL_DEFAULT_INCLUDE_CLOSURES
+    closures = GLOBAL_DEFAULT_CLOSURES
 
     # Deprecated
     warnonly = nothing
@@ -37,8 +37,8 @@ function parse_options(options, calling_module)
             elseif option.args[1] == :default_union_limit
                 union_limit = option.args[2]
                 continue
-            elseif option.args[1] == :default_include_closures
-                include_closures = option.args[2]
+            elseif option.args[1] == :default_closures
+                closures = option.args[2]
                 continue
             end
         end
@@ -48,7 +48,7 @@ function parse_options(options, calling_module)
     mode = _parse_even_if_expr(mode, calling_module, String)
     codegen_level = _parse(codegen_level, String)
     union_limit = _parse(union_limit, Int)
-    include_closures = _parse(include_closures, Bool)
+    closures = _parse(closures, Bool)
 
     _validate_mode(mode)
     _validate_codegen_level(codegen_level)
@@ -69,7 +69,7 @@ function parse_options(options, calling_module)
         mode
     end
 
-    options = StabilizationOptions(mode, codegen_level, union_limit, include_closures)
+    options = StabilizationOptions(mode, codegen_level, union_limit, closures)
 
     if calling_module != Core.Main
         # Local setting from Preferences.jl overrides defaults

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -7,11 +7,13 @@ struct StabilizationOptions
     mode::String
     codegen_level::String
     union_limit::Int
+    include_closures::Bool
 end
 
 const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
 const GLOBAL_DEFAULT_UNION_LIMIT = 1
+const GLOBAL_DEFAULT_INCLUDE_CLOSURES = false
 
 @enum IsCached::Bool begin
     Cached
@@ -29,6 +31,7 @@ const PREFERENCE_CACHE = (;
     mode=Cache{Base.UUID,Tuple{String,IsCached}}(),
     codegen_level=Cache{Base.UUID,Tuple{String,IsCached}}(),
     union_limit=Cache{Base.UUID,Tuple{Int,IsCached}}(),
+    include_closures=Cache{Base.UUID,Tuple{Bool,IsCached}}(),
 )
 # All of our preferences are compile-time only, so we can safely cache them
 
@@ -84,7 +87,9 @@ function get_all_preferred(options::StabilizationOptions, calling_module)
     )
     if mode == "disable"
         # Short circuit and quit early
-        return StabilizationOptions("disable", options.codegen_level, options.union_limit)
+        return StabilizationOptions(
+            "disable", options.codegen_level, options.union_limit, options.include_closures
+        )
     end
     return StabilizationOptions(
         mode,
@@ -101,6 +106,12 @@ function get_all_preferred(options::StabilizationOptions, calling_module)
             calling_module,
             "dispatch_doctor_union_limit",
             ["instability_check_union_limit"],
+        ),
+        get_preferred(
+            options.include_closures,
+            PREFERENCE_CACHE.include_closures,
+            calling_module,
+            "dispatch_doctor_include_closures",
         ),
     )
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -7,13 +7,13 @@ struct StabilizationOptions
     mode::String
     codegen_level::String
     union_limit::Int
-    include_closures::Bool
+    closures::Bool
 end
 
 const GLOBAL_DEFAULT_MODE = "error"
 const GLOBAL_DEFAULT_CODEGEN_LEVEL = "debug"
 const GLOBAL_DEFAULT_UNION_LIMIT = 1
-const GLOBAL_DEFAULT_INCLUDE_CLOSURES = false
+const GLOBAL_DEFAULT_CLOSURES = false
 
 @enum IsCached::Bool begin
     Cached
@@ -31,7 +31,7 @@ const PREFERENCE_CACHE = (;
     mode=Cache{Base.UUID,Tuple{String,IsCached}}(),
     codegen_level=Cache{Base.UUID,Tuple{String,IsCached}}(),
     union_limit=Cache{Base.UUID,Tuple{Int,IsCached}}(),
-    include_closures=Cache{Base.UUID,Tuple{Bool,IsCached}}(),
+    closures=Cache{Base.UUID,Tuple{Bool,IsCached}}(),
 )
 # All of our preferences are compile-time only, so we can safely cache them
 
@@ -88,7 +88,7 @@ function get_all_preferred(options::StabilizationOptions, calling_module)
     if mode == "disable"
         # Short circuit and quit early
         return StabilizationOptions(
-            "disable", options.codegen_level, options.union_limit, options.include_closures
+            "disable", options.codegen_level, options.union_limit, options.closures
         )
     end
     return StabilizationOptions(
@@ -108,10 +108,10 @@ function get_all_preferred(options::StabilizationOptions, calling_module)
             ["instability_check_union_limit"],
         ),
         get_preferred(
-            options.include_closures,
-            PREFERENCE_CACHE.include_closures,
+            options.closures,
+            PREFERENCE_CACHE.closures,
             calling_module,
-            "dispatch_doctor_include_closures",
+            "dispatch_doctor_closures",
         ),
     )
 end

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -37,7 +37,7 @@ function _stable(args...; calling_module, source_info, kws...)
             options.mode,
             options.codegen_level,
             options.union_limit,
-            options.include_closures,
+            options.closures,
         )
         if metadata.matching_function == 0
             @warn(
@@ -192,7 +192,7 @@ function _stabilize_fnc(
     mode::String="error",
     codegen_level::String="debug",
     union_limit::Int=0,
-    include_closures::Bool=false,
+    closures::Bool=false,
     source_info::Union{LineNumberNode,String,Nothing}=nothing,
 )
     func = splitdef(fex)
@@ -237,7 +237,7 @@ function _stabilize_fnc(
         return fex, UpwardMetadata(downward_metadata)
     end
 
-    (func[:body], upward_metadata) = if include_closures
+    (func[:body], upward_metadata) = if closures
         _stabilize_all(
             func[:body],
             # Fresh downward metadata, as we dont want
@@ -246,7 +246,7 @@ function _stabilize_fnc(
             mode,
             codegen_level,
             union_limit,
-            include_closures,
+            closures,
             source_info,
         )
     else

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -521,6 +521,31 @@ end
     # If it wrapped the closure, this would have thrown an error!
     @test Aclosuresunwrapped.f(1) == 1
 end
+@testitem "include_closures parameter" begin
+    using DispatchDoctor
+
+    @stable default_include_closures = true function f(x)
+        inner() = x > 0 ? x : 0.0
+        return inner
+    end
+
+    @test_throws TypeInstabilityError f(0)()
+    @test allow_unstable(f(1)) == 1
+
+    @stable default_include_closures = true function f2(x)
+        function f3()
+            function f4()
+                return x > 0 ? x : 0.0
+            end
+            return f4
+        end
+        return f3
+    end
+    f4 = f2(1)()
+    @test_throws TypeInstabilityError f4()
+    @test allow_unstable(() -> f2(1)()()) == 1
+    @test allow_unstable(() -> f2(0)()()) == 0.0
+end
 @testitem "avoid double stable in module" begin
     using DispatchDoctor: _stabilize_module
     using MacroTools: postwalk, @capture
@@ -1170,14 +1195,14 @@ end
     # various settings
     using FakePackage1
 
-    options = DDP.StabilizationOptions("d", "e", 6)
+    options = DDP.StabilizationOptions("d", "e", 6, false)
     @test DDP.get_all_preferred(options, FakePackage1) ==
-        DDP.StabilizationOptions("a", "b", 3)
+        DDP.StabilizationOptions("a", "b", 3, false)
 
     using FakePackage2
-    options = DDP.StabilizationOptions("d", "e", 6)
+    options = DDP.StabilizationOptions("d", "e", 6, false)
     @test DDP.get_all_preferred(options, FakePackage2) ==
-        DDP.StabilizationOptions("d", "alpha", 6)
+        DDP.StabilizationOptions("d", "alpha", 6, false)
 
     # FakePackage3 has no preferences
     using FakePackage3
@@ -1191,6 +1216,7 @@ end
         DDP.GLOBAL_DEFAULT_MODE,
         DDP.GLOBAL_DEFAULT_CODEGEN_LEVEL,
         DDP.GLOBAL_DEFAULT_UNION_LIMIT,
+        DDP.GLOBAL_DEFAULT_INCLUDE_CLOSURES,
     )
 end
 @testitem "warn on no matches" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -521,10 +521,10 @@ end
     # If it wrapped the closure, this would have thrown an error!
     @test Aclosuresunwrapped.f(1) == 1
 end
-@testitem "include_closures parameter" begin
+@testitem "closures parameter" begin
     using DispatchDoctor
 
-    @stable default_include_closures = true function f(x)
+    @stable default_closures = true function f(x)
         inner() = x > 0 ? x : 0.0
         return inner
     end
@@ -532,7 +532,7 @@ end
     @test_throws TypeInstabilityError f(0)()
     @test allow_unstable(f(1)) == 1
 
-    @stable default_include_closures = true function f2(x)
+    @stable default_closures = true function f2(x)
         function f3()
             function f4()
                 return x > 0 ? x : 0.0
@@ -1216,7 +1216,7 @@ end
         DDP.GLOBAL_DEFAULT_MODE,
         DDP.GLOBAL_DEFAULT_CODEGEN_LEVEL,
         DDP.GLOBAL_DEFAULT_UNION_LIMIT,
-        DDP.GLOBAL_DEFAULT_INCLUDE_CLOSURES,
+        DDP.GLOBAL_DEFAULT_CLOSURES,
     )
 end
 @testitem "warn on no matches" begin


### PR DESCRIPTION
@yebai this would allow detecting instabilities in the pullbacks of Mooncake.jl, even though the majority are defined as closure functions. (Before this PR, DD would automatically skip analysis of any closure)

```julia
julia> @stable default_closures = true function my_rrule()
           pb(_) = rand() > 0.5 ? 0.0 : 1
           return 1, pb
       end
my_rrule (generic function with 1 method)

julia> p, pb = my_rrule()
(1, pb)

julia> pb(0)
ERROR: DispatchDoctor.TypeInstabilityError: Instability detected in `pb` defined at REPL[1]:2 with arguments `(Int64,)`. Inferred to be `Union{Float64, Int64}`, which is not a concrete type.
Stacktrace:
 [1] (::var"#pb#14"{var"##pb_simulator#231#13"})(arg#230::Int64)
   @ Main ./none:0
 [2] top-level scope
   @ REPL[3]:1
```