### PR TITLE
Do not remove line number nodes from command literals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchDoctor"
 uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.4.26"
+version = "0.4.27"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/stabilization.jl
+++ b/src/stabilization.jl
@@ -1,7 +1,7 @@
 """This module holds the main processing functions for `@stable`"""
 module _Stabilization
 
-using MacroTools: @capture, @q, combinedef, splitdef, isdef, longdef, rmlines, prewalk
+using MacroTools: @capture, @q, combinedef, splitdef, isdef, longdef, prewalk
 
 using .._Utils:
     specializing_typeof,
@@ -13,7 +13,8 @@ using .._Utils:
     extract_symbol,
     type_instability,
     type_instability_limit_unions,
-    has_nospecialize
+    has_nospecialize,
+    safe_remove_lines
 using .._Errors: TypeInstabilityError, TypeInstabilityWarning
 using .._Interactions:
     ignore_function,
@@ -306,7 +307,7 @@ function _stabilize_fnc(
 
     func_simulator[:name] = simulator
     func_simulator[:body] = if codegen_level == "debug"
-        prewalk(rmlines, func_simulator[:body])
+        prewalk(safe_remove_lines, func_simulator[:body])
     else
         func_simulator[:body]
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,8 @@
 """This module contains various utility functions"""
 module _Utils
 
-using MacroTools: @capture
+using Base: isexpr
+using MacroTools: @capture, rmlines
 
 # Compatible Julia versions
 const JULIA_OK = let
@@ -188,5 +189,17 @@ function has_nospecialize(ex::Expr)
     return any(has_nospecialize, ex.args)
 end
 has_nospecialize(::Any) = false  # LCOV_EXCL_LINE
+
+is_cmd_ref(x::GlobalRef) = x.mod == Core && x.name == Symbol("@cmd")
+is_cmd_ref(x) = false
+
+function safe_remove_lines(x::Expr)
+    if isexpr(x, :macrocall) && is_cmd_ref(x.args[1])
+        x
+    else
+        rmlines(x)
+    end
+end
+safe_remove_lines(x) = rmlines(x)
 
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1385,5 +1385,12 @@ end
     @test_nowarn allow_unstable(() -> (allow_unstable(f); f()))
     @test_throws TypeInstabilityError f()
 end
+@testitem "issue with command literal syntax" begin
+    using DispatchDoctor
+
+    # MacroTools.rmlines creates an invalid expression for command literals.
+    # Instead, use `safe_remove_lines` to skip those expressions.
+    @test (@stable f() = ``) isa Function && f() isa Cmd
+end
 
 @run_package_tests


### PR DESCRIPTION
Closes #88.

You're right, it was in `rmlines`!