### PR TITLE
Fix overhead for @stable functions with Type arguments

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -106,10 +106,11 @@ function get_first_source_info(s::Expr)
 end
 
 # typeof but returns Type{T} for a type T input
-specializing_typeof(::T) where {T} = T
-specializing_typeof(::Type{T}) where {T} = Type{T}
-specializing_typeof(arg::Type{<:Type}) = typeof(arg)
-specializing_typeof(::Val{T}) where {T} = Val{T}
+# NOTE: avoid parametric `where` clauses here — they prevent the compiler
+# from constant-folding the map(specializing_typeof, args)... → _promote_op chain.
+specializing_typeof(x) = typeof(x)
+specializing_typeof(x::Type) = Type{x}
+specializing_typeof(x::Type{<:Type}) = typeof(x)
 map_specializing_typeof(args::Tuple) = map(specializing_typeof, args)
 
 function _promote_op(f::F, S::Vararg{Type,N}) where {F,N}

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1454,4 +1454,21 @@ end
     @test_throws TypeInstabilityError f()
 end
 
+@testitem "no overhead for Type arguments" begin
+    using DispatchDoctor
+
+    @stable gs(::Type{T}, x) where {T} = T(x)
+    g(::Type{Int}, x) = Int(x)
+
+    # warmup
+    map(x -> g(Int, x), 1:10)
+    map(x -> gs(Int, x), 1:10)
+
+    a_plain = @allocated map(x -> g(Int, x), 1:10^4)
+    a_stable = @allocated map(x -> gs(Int, x), 1:10^4)
+
+    # @stable should not cause orders-of-magnitude more allocations
+    @test a_stable < 3 * max(a_plain, 1000)
+end
+
 @run_package_tests


### PR DESCRIPTION
## Summary
- Fixes #98 — `@stable` functions with `::Type{T}` arguments had ~20x slowdown and orders-of-magnitude more allocations compared to plain functions
- Root cause: parametric `where {T}` clauses on `specializing_typeof` prevented the compiler from constant-folding the `map(specializing_typeof, args)... → _promote_op → Core.Compiler.return_type` chain
- Fix: replace with non-parametric equivalents (`typeof(x)`, `Type{x}`) that produce identical results but allow constant folding

## Test plan
- Added regression test checking that `@stable` with `Type` args doesn't cause more than 3x the allocations of a plain function
- Verified the test fails without the fix and passes with it
- Full existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)